### PR TITLE
Use a class to handle SMuRF packets

### DIFF
--- a/include/data_buffer.h
+++ b/include/data_buffer.h
@@ -37,8 +37,8 @@ private:
     std::size_t size;
     std::vector<SmurfPacket> data;
     typedef std::vector<SmurfPacket>::iterator dataIt;
-    typename std::vector<SmurfPacket>::iterator readPtr;
-    typename std::vector<SmurfPacket>::iterator writePtr;
+    dataIt readPtr;
+    dataIt writePtr;
     bool full;
     bool empty;
     int writeCnt;

--- a/include/data_buffer.h
+++ b/include/data_buffer.h
@@ -6,28 +6,19 @@
 #include <condition_variable>
 #include <mutex>
 
-// Buffer of SMuRF packets
-template <typename T>
+#include "smurf_packet.h"
+
 class DataBuffer
 {
 public:
-    DataBuffer(std::size_t d, std::size_t s);
+    DataBuffer(std::size_t s);
+    ~DataBuffer();
 
-    virtual ~DataBuffer();
+    SmurfPacket    getWritePtr();
+    SmurfPacket_RO getReadPtr();
 
-    // Get a pointer to the next empty cell in the buffer, ready to accept a
-    // new data packet.
-    T* getWritePtr();
-
-    // Get a pointer to the next available data packet, ready to be processed.
-    T* getReadPtr();
-
-    // Call after a new packet is fully written into the buffer. The writing pointer will be move forward
-    // to the next empty cell in the buffer.
     void doneWriting();
 
-    // Call after a packet is fully processed. The reading pointer will be move forward to the
-    // next cell in the buffer.
     void doneReading();
 
     const bool               isEmpty() const;
@@ -43,11 +34,11 @@ public:
     void printStatistic() const;
 
 private:
-    std::size_t depth;
     std::size_t size;
-    std::vector< std::vector<T> > data;
-    typename std::vector< std::vector<T> >::iterator readPtr;
-    typename std::vector< std::vector<T> >::iterator writePtr;
+    std::vector<SmurfPacket> data;
+    typedef std::vector<SmurfPacket>::iterator dataIt;
+    typename std::vector<SmurfPacket>::iterator readPtr;
+    typename std::vector<SmurfPacket>::iterator writePtr;
     bool full;
     bool empty;
     int writeCnt;
@@ -56,6 +47,8 @@ private:
     int ROFCnt;
     std::mutex              mutex;
     std::condition_variable dataReady;
+
+
 };
 
 #endif

--- a/include/data_buffer.h
+++ b/include/data_buffer.h
@@ -3,22 +3,33 @@
 
 #include <iostream>
 #include <vector>
+#include <deque>
+#include <iterator>
+#include <algorithm>
 #include <condition_variable>
 #include <mutex>
 
 #include "smurf_packet.h"
 
+// This class implements a data buffer between new Smurf packet created, and the readers.
+// At this moment there are 2 readers: the user custom transmitter, and file writer.
+// The implementation is a circular buffer, which will overwrite old data is the readers
+// don't process the packets fast enough.
+// Readers get read-only (smart) pointer to the data, not a copy of it. The writer on the other
+// hand receives a read-write (smart) pointer to the data cell.
 class DataBuffer
 {
 public:
-    DataBuffer(std::size_t s);
+    // Constructor. The arguments are the buffer size (bufSize) and the number of readers (numReaders).
+    DataBuffer(std::size_t bufSize, std::size_t numReaders);
     ~DataBuffer();
 
     // Get a pointer to the next available buffer slot, ready to be written to.
     SmurfPacket    getWritePtr();
 
     // Get a pointer to the next available data packet, ready to be processed.
-    SmurfPacket_RO getReadPtr();
+    // Argument is the reader index.
+    SmurfPacket_RO getReadPtr(std::size_t i);
 
     // Call after a new packet is fully written into the buffer. The writing
     // pointer will be move forward to the next empty cell in the buffer.
@@ -26,25 +37,32 @@ public:
 
     // Call after a packet is fully processed. The reading pointer
     // will be move forward to the next cell in the buffer.
-    void doneReading();
+    // Argument is the reader index.
+    void doneReading(std::size_t i);
 
-    // Get buffer empty status
-    const bool               isEmpty() const;
+    // Get buffer empty status for each reader.
+    // Argument is the reader index.
+    const bool               isEmpty(std::size_t i) const;
 
     // Get buffer full status
     const bool               isFull() const;
 
-    // Get number of read overflows
-    const int                getROFCnt() const;
+    // Get number of read overflows (number of read tries when buffer is empty) for each reader.
+    // Argument is the reader index.
+    const std::size_t        getROFCnt(std::size_t i) const;
 
-    // Get number of write overflows
-    const int                getWOFCnt() const;
+    // Get number of overwrites (number of time data have been overwrite) for each reader.
+    // Argument is the reader index.
+    const std::size_t        getOWCnt(std::size_t i) const;
 
-    // Clear overflow counters
-    void                     clearOFCnts();
+    // Clear counters
+    void                     clearCnts();
 
     // Get buffer size
     const std::size_t        getSize() const;
+
+    // Get the number of readers
+    const std::size_t        getNumReaders() const;
 
     // Get a pointer to the buffer mutex
     std::mutex*              getMutex();
@@ -56,18 +74,21 @@ public:
     void printStatistic() const;
 
 private:
-    std::size_t size;                               // Buffer size
-    std::vector<SmurfPacket> data;                  // Raw buffer data
-    std::vector<SmurfPacket>::iterator readPtr;     // Read iterator
-    std::vector<SmurfPacket>::iterator writePtr;    // Write iterator
-    bool full;                                      // Buffer full flag
-    bool empty;                                     // Buffer empty flag
-    int writeCnt;                                   // Write operation counter
-    int readCnt;                                    // Read operation counter
-    int WOFCnt;                                     // Write overflow counter
-    int ROFCnt;                                     // Read overflow counter
-    std::mutex              mutex;                  // Buffer mutex
-    std::condition_variable dataReady;              // New data ready conditional variable
+    typedef std::vector<SmurfPacket>::iterator data_it_t; // Iterator data type
+
+    std::size_t              size;          // Buffer size
+    std::size_t              numberReaders; // Number of readers
+    std::vector<SmurfPacket> data;          // Raw buffer data
+    std::vector<data_it_t>   readPtr;       // Read iterator (one for each reader)
+    data_it_t                writePtr;      // Write iterator
+    std::deque<bool>         full;          // Buffer full flag (one for each reader)
+    std::deque<bool>         empty;         // Buffer empty flag (one for each reader)
+    std::size_t              writeCnt;      // Write operation counter
+    std::vector<std::size_t> readCnt;       // Read operation counter (one for each reader)
+    std::vector<std::size_t> OWCnt;         // Overwrite counter (one for each reader)
+    std::vector<std::size_t> ROFCnt;        // Read overflow counter (one for each reader)
+    std::mutex               mutex;         // Buffer mutex
+    std::condition_variable  dataReady;     // New data ready conditional variable
 };
 
 #endif

--- a/include/data_buffer.h
+++ b/include/data_buffer.h
@@ -68,8 +68,6 @@ private:
     int ROFCnt;                                     // Read overflow counter
     std::mutex              mutex;                  // Buffer mutex
     std::condition_variable dataReady;              // New data ready conditional variable
-
-
 };
 
 #endif

--- a/include/data_buffer.h
+++ b/include/data_buffer.h
@@ -36,9 +36,9 @@ public:
 private:
     std::size_t size;
     std::vector<SmurfPacket> data;
-    typedef std::vector<SmurfPacket>::iterator dataIt;
-    dataIt readPtr;
-    dataIt writePtr;
+
+    std::vector<SmurfPacket>::iterator readPtr;
+    std::vector<SmurfPacket>::iterator writePtr;
     bool full;
     bool empty;
     int writeCnt;

--- a/include/data_buffer.h
+++ b/include/data_buffer.h
@@ -14,39 +14,60 @@ public:
     DataBuffer(std::size_t s);
     ~DataBuffer();
 
+    // Get a pointer to the next available buffer slot, ready to be written to.
     SmurfPacket    getWritePtr();
+
+    // Get a pointer to the next available data packet, ready to be processed.
     SmurfPacket_RO getReadPtr();
 
+    // Call after a new packet is fully written into the buffer. The writing
+    // pointer will be move forward to the next empty cell in the buffer.
     void doneWriting();
 
+    // Call after a packet is fully processed. The reading pointer
+    // will be move forward to the next cell in the buffer.
     void doneReading();
 
+    // Get buffer empty status
     const bool               isEmpty() const;
+
+    // Get buffer full status
     const bool               isFull() const;
+
+    // Get number of read overflows
     const int                getROFCnt() const;
+
+    // Get number of write overflows
     const int                getWOFCnt() const;
+
+    // Clear overflow counters
     void                     clearOFCnts();
+
+    // Get buffer size
     const std::size_t        getSize() const;
+
+    // Get a pointer to the buffer mutex
     std::mutex*              getMutex();
+
+    // Get a pointer to the new data ready conditional variable
     std::condition_variable* getDataReady();
 
-
+    // Print the buffer statistics information
     void printStatistic() const;
 
 private:
-    std::size_t size;
-    std::vector<SmurfPacket> data;
-
-    std::vector<SmurfPacket>::iterator readPtr;
-    std::vector<SmurfPacket>::iterator writePtr;
-    bool full;
-    bool empty;
-    int writeCnt;
-    int readCnt;
-    int WOFCnt;
-    int ROFCnt;
-    std::mutex              mutex;
-    std::condition_variable dataReady;
+    std::size_t size;                               // Buffer size
+    std::vector<SmurfPacket> data;                  // Raw buffer data
+    std::vector<SmurfPacket>::iterator readPtr;     // Read iterator
+    std::vector<SmurfPacket>::iterator writePtr;    // Write iterator
+    bool full;                                      // Buffer full flag
+    bool empty;                                     // Buffer empty flag
+    int writeCnt;                                   // Write operation counter
+    int readCnt;                                    // Read operation counter
+    int WOFCnt;                                     // Write overflow counter
+    int ROFCnt;                                     // Read overflow counter
+    std::mutex              mutex;                  // Buffer mutex
+    std::condition_variable dataReady;              // New data ready conditional variable
 
 
 };

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -181,6 +181,10 @@ private:
   std::vector<uint8_t>   headerBuffer;  // Header buffer
   std::vector<avgdata_t> payloadBuffer; // Payload buffer
   SmurfHeader            header;        // Packet header object
+
+  // Get a word from the header
+  template<typename T>
+  const T getHeaderWord(std::size_t offset) const;
 };
 
 #endif

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -81,6 +81,8 @@ public:
   uint32_t epics_nanoseconds;
 
   SmurfHeader(void); // creates header with num samples
+  SmurfHeader(uint8_t *buffer); // creates header and set pointer
+
   void copy_header(uint8_t *buffer);
   uint get_version(void);
   uint get_ext_counter(void);

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -133,6 +133,12 @@ public:
   // Get the total length of the packet in number of bytes
   const std::size_t getPacketLength()  const;
 
+  // Get a copy of the header bufefr as an array of bytes
+  void getHeaderArray(uint8_t* h) const;
+
+  // Get a copy of the data buffer as an array of avgdata_t
+  void getDataArray(avgdata_t* d) const;
+
   // Header functions //
   const uint8_t  getVersion()                   const;  // Get protocol version
   const uint8_t  getCrateID()                   const;  // Get ATCA crate ID
@@ -162,23 +168,17 @@ public:
   const uint16_t getRowLength()                 const;  // Get MCE header value
   const uint16_t getDataRate()                  const;  // Get MCE header value
 
-  // Write the packet into a file
-  void writeToFile(uint fd) const;
-
   // Get a pointer to a SmurfHeader object, to access the header information
   SmurfHeader* getHeaderPtr();
 
   // Get a data value, at a specified index
   const avgdata_t getValue(std::size_t index) const;
 
-  // Get a byte from the header, at a specified index
+  // Get a raw byte from the header, at a specified index
   const uint8_t getHeaderByte(std::size_t index) const;
 
-  // Get a copy of the header bufefr as an array of bytes
-  void getHeaderArray(uint8_t* h) const;
-
-  // Get a copy of the data buffer as an array of avgdata_t
-  void getDataArray(avgdata_t* d) const;
+  // Write the packet into a file
+  void writeToFile(uint fd) const;
 
 protected:
   std::size_t            headerLength;  // Header length (number of bytes)
@@ -243,11 +243,40 @@ public:
   // Copy an array of avgdata_t's into the payload
   void copyData(avgdata_t* d);
 
+  // Header functions //
+  void setVersion();                  // Get protocol version
+  void setCrateID();                  // Get ATCA crate ID
+  void setSlotNumber();               // Get ATCA slot number
+  void setTimingConfiguration();      // Get timing configuration
+  void setNumberChannels();           // Get number of channel in this packet
+  void setTESBias(std::size_t index); // Get TES DAC values 16X 20 bit
+  void setUnixTime();                 // Get 64 bit unix time nanoseconds
+  void setFluxRampIncrement();        // Get signed 32 bit integer for increment
+  void setFluxRampOffset();           // Get signed 32 it integer for offset
+  void setCounter0();                 // Get 32 bit counter since last 1Hz marker
+  void setCounter1();                 // Get 32 bit counter since last external input
+  void setCounter2();                 // Get 64 bit timestamp
+  void setAveragingResetBits();       // Get up to 32 bits of average reset from timing system
+  void setFrameCounter();             // Get locally genreate frame counter 32 bit
+  void setTESRelaySetting();          // Get TES and flux ramp relays, 17bits in use now
+  void setExternalTimeClock();        // Get Syncword from mce for mce based systems (40 bit including header)
+  void setControlField();             // Get control field word
+  void setClearAverageBit();          // Get control field's clear average and unwrap bit (bit 0)
+  void setDisableStreamBit();         // Get control field's disable stream to MCE bit (bit 1)
+  void setDisableFileWriteBit();      // Get control field's disable file write (bit 2)
+  void setReadConfigEachCycleBit();   // Get control field's set to read configuration file each cycle bit (bit 3)
+  void setTestMode();                 // Get control field's test mode (bits 4-7)
+  void setTestParameters();           // Get test parameters
+  void setNumberRows();               // Get MCE header value (max 255) (defaluts to 33 if 0)
+  void setNumberRowsReported();       // Get MCE header value (defaults to numb rows if 0)
+  void setRowLength();                // Get MCE header value
+  void setDataRate();                 // Get MCE header value
+
+  // Set a raw byte in the header, at a specific index
+  void setHeaderByte(std::size_t index, uint8_t value);
+
   // Set a data value, at a specific index
   void setValue(std::size_t index, avgdata_t value);
-
-  // Set a byte on the header, at a specific index
-  void setHeaderByte(std::size_t index, uint8_t value);
 };
 
 #endif

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <sys/timeb.h>
 #include <vector>
+#include <stdexcept>
 
 #include "common.h"
 #include "tes_bias_array.h"
@@ -242,33 +243,33 @@ public:
   void copyData(avgdata_t* d);
 
   // Header functions //
-  void setVersion();                  // Get protocol version
-  void setCrateID();                  // Get ATCA crate ID
-  void setSlotNumber();               // Get ATCA slot number
-  void setTimingConfiguration();      // Get timing configuration
-  void setNumberChannels();           // Get number of channel in this packet
-  void setTESBias(std::size_t index); // Get TES DAC values 16X 20 bit
-  void setUnixTime();                 // Get 64 bit unix time nanoseconds
-  void setFluxRampIncrement();        // Get signed 32 bit integer for increment
-  void setFluxRampOffset();           // Get signed 32 it integer for offset
-  void setCounter0();                 // Get 32 bit counter since last 1Hz marker
-  void setCounter1();                 // Get 32 bit counter since last external input
-  void setCounter2();                 // Get 64 bit timestamp
-  void setAveragingResetBits();       // Get up to 32 bits of average reset from timing system
-  void setFrameCounter();             // Get locally genreate frame counter 32 bit
-  void setTESRelaySetting();          // Get TES and flux ramp relays, 17bits in use now
-  void setExternalTimeClock();        // Get Syncword from mce for mce based systems (40 bit including header)
-  void setControlField();             // Get control field word
-  void setClearAverageBit();          // Get control field's clear average and unwrap bit (bit 0)
-  void setDisableStreamBit();         // Get control field's disable stream to MCE bit (bit 1)
-  void setDisableFileWriteBit();      // Get control field's disable file write (bit 2)
-  void setReadConfigEachCycleBit();   // Get control field's set to read configuration file each cycle bit (bit 3)
-  void setTestMode();                 // Get control field's test mode (bits 4-7)
-  void setTestParameters();           // Get test parameters
-  void setNumberRows();               // Get MCE header value (max 255) (defaluts to 33 if 0)
-  void setNumberRowsReported();       // Get MCE header value (defaults to numb rows if 0)
-  void setRowLength();                // Get MCE header value
-  void setDataRate();                 // Get MCE header value
+  void setVersion(uint8_t value);                     // Get protocol version
+  void setCrateID(uint8_t value);                     // Get ATCA crate ID
+  void setSlotNumber(uint8_t value);                  // Get ATCA slot number
+  void setTimingConfiguration(uint8_t value);         // Get timing configuration
+  void setNumberChannels(uint32_t value);             // Get number of channel in this packet
+  void setTESBias(std::size_t index, int32_t value);  // Get TES DAC values 16X 20 bit
+  void setUnixTime(uint64_t value);                   // Get 64 bit unix time nanoseconds
+  void setFluxRampIncrement(uint32_t value);          // Get signed 32 bit integer for increment
+  void setFluxRampOffset(uint32_t value);             // Get signed 32 it integer for offset
+  void setCounter0(uint32_t value);                   // Get 32 bit counter since last 1Hz marker
+  void setCounter1(uint32_t value);                   // Get 32 bit counter since last external input
+  void setCounter2(uint64_t value);                   // Get 64 bit timestamp
+  void setAveragingResetBits(uint32_t value);         // Get up to 32 bits of average reset from timing system
+  void setFrameCounter(uint32_t value);               // Get locally genreate frame counter 32 bit
+  void setTESRelaySetting(uint32_t value);            // Get TES and flux ramp relays, 17bits in use now
+  void setExternalTimeClock(uint64_t value);          // Get Syncword from mce for mce based systems (40 bit including header)
+  void setControlField(uint8_t value);                // Get control field word
+  void setClearAverageBit(bool value);                // Get control field's clear average and unwrap bit (bit 0)
+  void setDisableStreamBit(bool value);               // Get control field's disable stream to MCE bit (bit 1)
+  void setDisableFileWriteBit(bool value);            // Get control field's disable file write (bit 2)
+  void setReadConfigEachCycleBit(bool value);         // Get control field's set to read configuration file each cycle bit (bit 3)
+  void setTestMode(uint8_t value);                    // Get control field's test mode (bits 4-7)
+  void setTestParameters(uint8_t value);              // Get test parameters
+  void setNumberRows(uint16_t value);                 // Get MCE header value (max 255) (defaluts to 33 if 0)
+  void setNumberRowsReported(uint16_t value);         // Get MCE header value (defaults to numb rows if 0)
+  void setRowLength(uint16_t value);                  // Get MCE header value
+  void setDataRate(uint16_t value);                   // Get MCE header value
 
   // Set a raw byte in the header, at a specific index
   void setHeaderByte(std::size_t index, uint8_t value);
@@ -280,6 +281,9 @@ private:
   // Get a word from the header
   template<typename T>
   void setHeaderWord(std::size_t offset, const T& value);
+
+  // Set bit number 'index' to 'value' in the word 'byte'
+  uint8_t setWordBit(uint8_t byte, std::size_t index, bool value);
 };
 
 #endif

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -177,6 +177,11 @@ public:
   // Write the packet into a file
   void writeToFile(uint fd) const;
 
+private:
+  // Get a word from the header
+  template<typename T>
+  const T getHeaderWord(std::size_t offset) const;
+
 protected:
   std::size_t            headerLength;  // Header length (number of bytes)
   std::size_t            payloadLength; // Payload size (number of avgdata_t)
@@ -185,10 +190,6 @@ protected:
   std::vector<avgdata_t> payloadBuffer; // Payload buffer
   SmurfHeader            header;        // Packet header object
   TesBiasArray           tba;           // Tes Bias array object
-
-  // Get a word from the header
-  template<typename T>
-  const T getHeaderWord(std::size_t offset) const;
 
   // Header word offsets (in bytes)
   static const std::size_t headerVersionOffset              = 0;

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -9,6 +9,7 @@
 #include <sys/timeb.h>
 #include <vector>
 #include <stdexcept>
+#include <memory>
 
 #include "common.h"
 #include "tes_bias_array.h"
@@ -113,10 +114,16 @@ public:
   void clear_average(); // clears aveage counters
 };
 
+
+class ISmurfPacket_RO;
+class ISmurfPacket;
+typedef std::shared_ptr<ISmurfPacket_RO>  SmurfPacket_RO;
+typedef std::shared_ptr<ISmurfPacket>     SmurfPacket;
+
 // SmurfPakcet Class
 // This class handler SMuRF packets.
 // This class gives a read-only interface
-class SmurfPacket_RO
+class ISmurfPacket_RO
 {
 public:
   // Get the length of the header in number of bytes
@@ -172,14 +179,17 @@ public:
   // Write the packet into a file
   void writeToFile(uint fd) const;
 
+  // Factory method, which return a smart pointer to a SmurfPacket object
+  static SmurfPacket_RO create(const SmurfPacket& sp);
+
 protected:
-  // Prevent construction of SmurfPacket with RO interface.
-  // SmurfPacket must be created with a RW interface, and this class
+  // Prevent construction of ISmurfPacket with RO interface.
+  // ISmurfPacket must be created with a RW interface, and this class
   // can be used to give read only access to the data.
-  SmurfPacket_RO();
-  SmurfPacket_RO(const SmurfPacket_RO&);
-  SmurfPacket_RO& operator=(const SmurfPacket_RO&);
-  virtual ~SmurfPacket_RO();
+  ISmurfPacket_RO();
+  ISmurfPacket_RO(const ISmurfPacket_RO&);
+  ISmurfPacket_RO& operator=(const ISmurfPacket_RO&);
+  virtual ~ISmurfPacket_RO();
 
   std::size_t            headerLength;  // Header length (number of bytes)
   std::size_t            payloadLength; // Payload size (number of avgdata_t)
@@ -231,20 +241,20 @@ private:
 // SmurfPakcet Class
 // This class handler SMuRF packets.
 // This class gives a full read-write interface
-class SmurfPacket : public SmurfPacket_RO
+class ISmurfPacket : public ISmurfPacket_RO
 {
 public:
   // Default constructor
-  SmurfPacket();
+  ISmurfPacket();
 
   // Constructor using a raw array for the header data
-  SmurfPacket(uint8_t* h);
+  ISmurfPacket(uint8_t* h);
 
   // Constructor using a raw array for the header and payload data
-  SmurfPacket(uint8_t* h, avgdata_t* d);
+  ISmurfPacket(uint8_t* h, avgdata_t* d);
 
   // Destructor
-  virtual ~SmurfPacket();
+  virtual ~ISmurfPacket();
 
   // Copy an array of bytes into the header
   void copyHeader(uint8_t* h);
@@ -286,6 +296,11 @@ public:
 
   // Set a data value, at a specific index
   void setValue(std::size_t index, avgdata_t value);
+
+  // Factory methods, which return smart pointer
+  static SmurfPacket create();
+  static SmurfPacket create(uint8_t* h);
+  static SmurfPacket create(uint8_t* h, avgdata_t* d);
 
 private:
   // Get a word from the header

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -216,6 +216,12 @@ protected:
   static const std::size_t headerRowLengthOffset            = 120;
   static const std::size_t headerDataRateOffset             = 122;
 
+  // Header's control field bit offset
+  static const std::size_t clearAvergaveBitOffset           = 0;
+  static const std::size_t disableStreamBitOffset           = 1;
+  static const std::size_t disableFileWriteBitOffset        = 2;
+  static const std::size_t readConfigEachCycleBitOffset     = 3;
+
 };
 
 // SmurfPakcet Class

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -183,6 +183,9 @@ private:
   template<typename T>
   const T getHeaderWord(std::size_t offset) const;
 
+  // Get the bit number 'index' of the word 'byte'
+  const bool getWordBit(uint8_t byte, std::size_t index) const;
+
 protected:
   std::size_t            headerLength;  // Header length (number of bytes)
   std::size_t            payloadLength; // Payload size (number of avgdata_t)

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -139,33 +139,33 @@ public:
   const std::size_t getPacketLength()  const;
 
   // Header functions //
-  const uint8_t  getVersion()                 const;  // Get protocol version
-  const uint8_t  getCrateID()                 const;  // Get ATCA crate ID
-  const uint8_t  getSlotNumber()              const;  // Get ATCA slot number
-  const uint8_t  getTimingConfiguration()     const;  // Get timing configuration
-  const uint32_t getNumberChannels()          const;  // Get number of channel in this packet
-  const int32_t  getTESDAC(std::size_t index) const;  // Get TES DAC values 16X 20 bit
-  const uint64_t getUnixTime()                const;  // Get 64 bit unix time nanoseconds
-  const uint32_t getFluxRampIncrement()       const;  // Get signed 32 bit integer for increment
-  const uint32_t getFluxRampOffset()          const;  // Get signed 32 it integer for offset
-  const uint32_t getCounter0()                const;  // Get 32 bit counter since last 1Hz marker
-  const uint32_t getCounter1()                const;  // Get 32 bit counter since last external input
-  const uint64_t getCounter2()                const;  // Get 64 bit timestamp
-  const uint32_t getAveragingResetBits()      const;  // Get up to 32 bits of average reset from timing system
-  const uint32_t getFrameCounter()            const;  // Get locally genreate frame counter 32 bit
-  const uint32_t getTESRelaySetting()         const;  // Get TES and flux ramp relays, 17bits in use now
-  const uint64_t getExternalTimeClock()       const;  // Get Syncword from mce for mce based systems (40 bit including header)
-  const uint8_t  getControlField()            const;  // Get control field word
-  const bool     getClearAverageBit()         const;  // Get control field's clear average and unwrap bit (bit 0)
-  const bool     getDisableStreamBit()        const;  // Get control field's disable stream to MCE bit (bit 1)
-  const bool     getDisableFileWriteBit()     const;  // Get control field's disable file write (bit 2)
-  const bool     getReadConfigEachCycleBit()  const;  // Get control field's set to read configuration file each cycle bit (bit 3)
-  const uint8_t  getTestMode()                const;  // Get control field's test mode (bits 4-7)
-  const uint8_t  getTestParameters()          const;  // Get test parameters
-  const uint16_t getNumberRows()              const;  // Get MCE header value (max 255) (defaluts to 33 if 0)
-  const uint16_t getNumberRowsReported()      const;  // Get MCE header value (defaults to numb rows if 0)
-  const uint16_t getRowLength()               const;  // Get MCE header value
-  const uint16_t getDataRate()                const;  // Get MCE header value
+  const uint8_t  getVersion()                   const;  // Get protocol version
+  const uint8_t  getCrateID()                   const;  // Get ATCA crate ID
+  const uint8_t  getSlotNumber()                const;  // Get ATCA slot number
+  const uint8_t  getTimingConfiguration()       const;  // Get timing configuration
+  const uint32_t getNumberChannels()            const;  // Get number of channel in this packet
+  const int32_t  getTESBias(std::size_t index)  const;  // Get TES DAC values 16X 20 bit
+  const uint64_t getUnixTime()                  const;  // Get 64 bit unix time nanoseconds
+  const uint32_t getFluxRampIncrement()         const;  // Get signed 32 bit integer for increment
+  const uint32_t getFluxRampOffset()            const;  // Get signed 32 it integer for offset
+  const uint32_t getCounter0()                  const;  // Get 32 bit counter since last 1Hz marker
+  const uint32_t getCounter1()                  const;  // Get 32 bit counter since last external input
+  const uint64_t getCounter2()                  const;  // Get 64 bit timestamp
+  const uint32_t getAveragingResetBits()        const;  // Get up to 32 bits of average reset from timing system
+  const uint32_t getFrameCounter()              const;  // Get locally genreate frame counter 32 bit
+  const uint32_t getTESRelaySetting()           const;  // Get TES and flux ramp relays, 17bits in use now
+  const uint64_t getExternalTimeClock()         const;  // Get Syncword from mce for mce based systems (40 bit including header)
+  const uint8_t  getControlField()              const;  // Get control field word
+  const bool     getClearAverageBit()           const;  // Get control field's clear average and unwrap bit (bit 0)
+  const bool     getDisableStreamBit()          const;  // Get control field's disable stream to MCE bit (bit 1)
+  const bool     getDisableFileWriteBit()       const;  // Get control field's disable file write (bit 2)
+  const bool     getReadConfigEachCycleBit()    const;  // Get control field's set to read configuration file each cycle bit (bit 3)
+  const uint8_t  getTestMode()                  const;  // Get control field's test mode (bits 4-7)
+  const uint8_t  getTestParameters()            const;  // Get test parameters
+  const uint16_t getNumberRows()                const;  // Get MCE header value (max 255) (defaluts to 33 if 0)
+  const uint16_t getNumberRowsReported()        const;  // Get MCE header value (defaults to numb rows if 0)
+  const uint16_t getRowLength()                 const;  // Get MCE header value
+  const uint16_t getDataRate()                  const;  // Get MCE header value
 
   // Copy an array of bytes into the header
   void copyHeader(uint8_t* h);

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -144,6 +144,29 @@ public:
   const uint8_t  getTimingConfiguration() const;  // Get timing configuration
   const uint32_t getNumberChannels()      const;  // Get number of channel in this packet
 
+  const uint32_t getTESDAC(std::size_t index) const;  // Get TES DAC values 16X 20 bit
+  const uint64_t getUnixTime()                const;  // Get 64 bit unix time nanoseconds
+  const uint32_t getFluxRampIncrement()       const;  // Get signed 32 bit integer for increment
+  const uint32_t getFluxRampOffset()          const;  // Get signed 32 it integer for offset
+  const uint32_t getCounter0()                const;  // Get 32 bit counter since last 1Hz marker
+  const uint32_t getCounter1()                const;  // Get 32 bit counter since last external input
+  const uint64_t getCounter2()                const;  // Get 64 bit timestamp
+  const uint32_t getAveragingResetBits()      const;  // Get up to 32 bits of average reset from timing system
+  const uint32_t getFrameCounter()            const;  // Get locally genreate frame counter 32 bit
+  const uint32_t getTESRelaySetting()         const;  // Get TES and flux ramp relays, 17bits in use now
+  const uint64_t getExternalTimeClock()       const;  // Get Syncword from mce for mce based systems (40 bit including header)
+  const uint8_t  getControlField()            const;  // Get control field word
+  const bool     getClearAverageBit()         const;  // Get control field's clear average and unwrap bit (bit 0)
+  const bool     getDisableStreamBit()        const;  // Get control field's disable stream to MCE bit (bit 1)
+  const bool     getDisableFileWriteBit()     const;  // Get control field's disable file write (bit 2)
+  const bool     getReadConfigEachCycleBit()  const;  // Get control field's set to read configuration file each cycle bit (bit 3)
+  const uint8_t  getTestMode()                const;  // Get control field's test mode (bits 4-7)
+  const uint8_t  getTestParameters()          const;  // Get test parameters
+  const uint16_t getNumberRows()              const;  // Get MCE header value (max 255) (defaluts to 33 if 0)
+  const uint16_t getNumberRowsReported()      const;  // Get MCE header value (defaults to numb rows if 0)
+  const uint16_t getRowLength()               const;  // Get MCE header value
+  const uint16_t getDataRate()                const;  // Get MCE header value
+
   // Copy an array of bytes into the header
   void copyHeader(uint8_t* h);
 

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -161,6 +161,12 @@ public:
   // Set a byte on the header, at a specific index
   void setHeaderByte(std::size_t index, uint8_t value);
 
+  // Get a copy of the header bufefr as an array of bytes
+  void getHeaderArray(uint8_t* h) const;
+
+  // Get a copy of the data buffer as an array of avgdata_t
+  void getDataArray(avgdata_t* d) const;
+
 private:
   std::size_t            headerLength;  // Header length (number of bytes)
   std::size_t            payloadLength; // Payload size (number of avgdata_t)

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -121,14 +121,8 @@ public:
   // Default constructor
   SmurfPacket_RO();
 
-  // Constructor using a raw array for the header data
-  SmurfPacket_RO(uint8_t* h);
-
-  // Constructor using a raw array for the header and payload data
-  SmurfPacket_RO(uint8_t* h, avgdata_t* d);
-
   // Destructor
-  ~SmurfPacket_RO();
+  virtual ~SmurfPacket_RO();
 
   // Get the length of the header in number of bytes
   const std::size_t getHeaderLength()  const;
@@ -168,12 +162,6 @@ public:
   const uint16_t getRowLength()                 const;  // Get MCE header value
   const uint16_t getDataRate()                  const;  // Get MCE header value
 
-  // Copy an array of bytes into the header
-  void copyHeader(uint8_t* h);
-
-  // Copy an array of avgdata_t's into the payload
-  void copyData(avgdata_t* d);
-
   // Write the packet into a file
   void writeToFile(uint fd) const;
 
@@ -183,14 +171,8 @@ public:
   // Get a data value, at a specified index
   const avgdata_t getValue(std::size_t index) const;
 
-  // Set a data value, at a specific index
-  void setValue(std::size_t index, avgdata_t value);
-
   // Get a byte from the header, at a specified index
   const uint8_t getHeaderByte(std::size_t index) const;
-
-  // Set a byte on the header, at a specific index
-  void setHeaderByte(std::size_t index, uint8_t value);
 
   // Get a copy of the header bufefr as an array of bytes
   void getHeaderArray(uint8_t* h) const;
@@ -198,7 +180,7 @@ public:
   // Get a copy of the data buffer as an array of avgdata_t
   void getDataArray(avgdata_t* d) const;
 
-private:
+protected:
   std::size_t            headerLength;  // Header length (number of bytes)
   std::size_t            payloadLength; // Payload size (number of avgdata_t)
   std::size_t            packetLength;  // Total packet length (number of bytes)
@@ -235,6 +217,37 @@ private:
   static const std::size_t headerRowLengthOffset            = 120;
   static const std::size_t headerDataRateOffset             = 122;
 
+};
+
+// SmurfPakcet Class
+// This class handler SMuRF packets.
+// This class gives read and write access to the packet content
+class SmurfPacket : public SmurfPacket_RO
+{
+public:
+  // Default constructor
+  SmurfPacket();
+
+  // Constructor using a raw array for the header data
+  SmurfPacket(uint8_t* h);
+
+  // Constructor using a raw array for the header and payload data
+  SmurfPacket(uint8_t* h, avgdata_t* d);
+
+  // Destructor
+  virtual ~SmurfPacket();
+
+  // Copy an array of bytes into the header
+  void copyHeader(uint8_t* h);
+
+  // Copy an array of avgdata_t's into the payload
+  void copyData(avgdata_t* d);
+
+  // Set a data value, at a specific index
+  void setValue(std::size_t index, avgdata_t value);
+
+  // Set a byte on the header, at a specific index
+  void setHeaderByte(std::size_t index, uint8_t value);
 };
 
 #endif

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -185,6 +185,31 @@ private:
   // Get a word from the header
   template<typename T>
   const T getHeaderWord(std::size_t offset) const;
+
+  // Header word offsets (in bytes)
+  static const std::size_t headerVersionOffset              = 0;
+  static const std::size_t headerCrateIDOffset              = 1;
+  static const std::size_t headerSlotNumberOffset           = 2;
+  static const std::size_t headerTimingConfigurationOffset  = 3;
+  static const std::size_t headerNumberChannelOffset        = 4;
+  static const std::size_t headerTESDACOffset               = 8;
+  static const std::size_t headerUnixTimeOffset             = 48;
+  static const std::size_t headerFluxRampIncrementOffset    = 56;
+  static const std::size_t headerFluxRampOffsetOffset       = 60;
+  static const std::size_t headerCounter0Offset             = 64;
+  static const std::size_t headerCounter1Offset             = 68;
+  static const std::size_t headerCounter2Offset             = 72;
+  static const std::size_t headerAveragingResetBitsOffset   = 80;
+  static const std::size_t headerFrameCounterOffset         = 84;
+  static const std::size_t headerTESRelaySettingOffset      = 88;
+  static const std::size_t headerExternalTimeClockOffset    = 96;
+  static const std::size_t headerControlFieldOffset         = 104;
+  static const std::size_t headerTestParametersOffset       = 105;
+  static const std::size_t headerNumberRowsOffset           = 112;
+  static const std::size_t headerNumberRowsReportedOffset   = 114;
+  static const std::size_t headerRowLengthOffset            = 120;
+  static const std::size_t headerDataRateOffset             = 122;
+
 };
 
 #endif

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -275,6 +275,11 @@ public:
 
   // Set a data value, at a specific index
   void setValue(std::size_t index, avgdata_t value);
+
+private:
+  // Get a word from the header
+  template<typename T>
+  void setHeaderWord(std::size_t offset, const T& value);
 };
 
 #endif

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -114,20 +114,21 @@ public:
 
 // SmurfPakcet Class
 // This class handler SMuRF packets.
-class SmurfPacket
+// This class gives only read access to the packet content
+class SmurfPacket_RO
 {
 public:
   // Default constructor
-  SmurfPacket();
+  SmurfPacket_RO();
 
   // Constructor using a raw array for the header data
-  SmurfPacket(uint8_t* h);
+  SmurfPacket_RO(uint8_t* h);
 
   // Constructor using a raw array for the header and payload data
-  SmurfPacket(uint8_t* h, avgdata_t* d);
+  SmurfPacket_RO(uint8_t* h, avgdata_t* d);
 
   // Destructor
-  ~SmurfPacket();
+  ~SmurfPacket_RO();
 
   // Get the length of the header in number of bytes
   const std::size_t getHeaderLength()  const;

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -115,16 +115,10 @@ public:
 
 // SmurfPakcet Class
 // This class handler SMuRF packets.
-// This class gives only read access to the packet content
+// This class gives a read-only interface
 class SmurfPacket_RO
 {
 public:
-  // Default constructor
-  SmurfPacket_RO();
-
-  // Destructor
-  virtual ~SmurfPacket_RO();
-
   // Get the length of the header in number of bytes
   const std::size_t getHeaderLength()  const;
 
@@ -178,15 +172,15 @@ public:
   // Write the packet into a file
   void writeToFile(uint fd) const;
 
-private:
-  // Get a word from the header
-  template<typename T>
-  const T getHeaderWord(std::size_t offset) const;
-
-  // Get the bit number 'index' of the word 'byte'
-  const bool getWordBit(uint8_t byte, std::size_t index) const;
-
 protected:
+  // Prevent construction of SmurfPacket with RO interface.
+  // SmurfPacket must be created with a RW interface, and this class
+  // can be used to give read only access to the data.
+  SmurfPacket_RO();
+  SmurfPacket_RO(const SmurfPacket_RO&);
+  SmurfPacket_RO& operator=(const SmurfPacket_RO&);
+  virtual ~SmurfPacket_RO();
+
   std::size_t            headerLength;  // Header length (number of bytes)
   std::size_t            payloadLength; // Payload size (number of avgdata_t)
   std::size_t            packetLength;  // Total packet length (number of bytes)
@@ -225,11 +219,18 @@ protected:
   static const std::size_t disableFileWriteBitOffset        = 2;
   static const std::size_t readConfigEachCycleBitOffset     = 3;
 
+private:
+  // Get a word from the header
+  template<typename T>
+  const T getHeaderWord(std::size_t offset) const;
+
+  // Get the bit number 'index' of the word 'byte'
+  const bool getWordBit(uint8_t byte, std::size_t index) const;
 };
 
 // SmurfPakcet Class
 // This class handler SMuRF packets.
-// This class gives read and write access to the packet content
+// This class gives a full read-write interface
 class SmurfPacket : public SmurfPacket_RO
 {
 public:

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -158,7 +158,8 @@ public:
   // Get a byte from the header, at a specified index
   const uint8_t getHeaderByte(std::size_t index) const;
 
-
+  // Set a byte on the header, at a specific index
+  void setHeaderByte(std::size_t index, uint8_t value);
 
 private:
   std::size_t            headerLength;  // Header length (number of bytes)

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -137,6 +137,13 @@ public:
   // Get the total length of the packet in number of bytes
   const std::size_t getPacketLength()  const;
 
+  // Header function //
+  const uint8_t  getVersion()             const;  // Get protocol version
+  const uint8_t  getCrateID()             const;  // Get ATCA crate ID
+  const uint8_t  getSlotNumber()          const;  // Get ATCA slot number
+  const uint8_t  getTimingConfiguration() const;  // Get timing configuration
+  const uint32_t getNumberChannels()      const;  // Get number of channel in this packet
+
   // Copy an array of bytes into the header
   void copyHeader(uint8_t* h);
 

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -1,13 +1,17 @@
 #ifndef _SMURF_PACKET_H_
 #define _SMURF_PACKET_H_
 
+#include <iostream>
 #include <stdint.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <string.h>
 #include <sys/timeb.h>
+#include <vector>
 
 #include "common.h"
+
+#include "smurf2mce.h"
 
 uint64_t pull_bit_field(uint8_t *ptr, uint offset, uint width);
 
@@ -55,6 +59,9 @@ const int h_data_rate_offset = 122;
 const int h_data_rate_width = 2;
 
 
+// SmurfHeader class
+// This class contains methods to access the different elements
+// in the SmurfHeader.
 class SmurfHeader //generates and decodes SMURF data header
 {
 public:
@@ -100,6 +107,59 @@ public:
   void put_field(int offset, int width, void *data);  // for adding to smurf header
 
   void clear_average(); // clears aveage counters
+};
+
+// SmurfPakcet Class
+// This class handler SMuRF packets.
+class SmurfPacket
+{
+public:
+  // Default constructor
+  SmurfPacket();
+
+  // Constructor using a raw array for the header data
+  SmurfPacket(uint8_t* h);
+
+  // Constructor using a raw array for the header and payload data
+  SmurfPacket(uint8_t* h, avgdata_t* d);
+
+  // Destructor
+  ~SmurfPacket();
+
+  // Get the length of the header in number of bytes
+  const std::size_t getHeaderLength()  const;
+
+  // Get the length of the payload in number of avgdata_t words
+  const std::size_t getPayloadLength() const;
+
+  // Get the total length of the packet in number of bytes
+  const std::size_t getPacketLength()  const;
+
+  // Copy an array of bytes into the header
+  void copyHeader(uint8_t* h);
+
+  // Copy an array of avgdata_t's into the payload
+  void copyData(avgdata_t* d);
+
+  // Write the packet into a file
+  void writeToFile(uint fd) const;
+
+  // Get a pointer to a SmurfHeader object, to access the header information
+  SmurfHeader* getHeaderPtr();
+
+  // Get a data value, at a specified index
+  const avgdata_t getData(std::size_t index) const;
+
+  // Get a byte from the header, at a specified index
+  const uint8_t getHeaderByte(std::size_t index) const;
+
+private:
+  std::size_t            headerLength;  // Header length (number of bytes)
+  std::size_t            payloadLength; // Payload size (number of avgdata_t)
+  std::size_t            packetLength;  // Total packet length (number of bytes)
+  std::vector<uint8_t>   headerBuffer;  // Header buffer
+  std::vector<avgdata_t> payloadBuffer; // Payload buffer
+  SmurfHeader            header;        // Packet header object
 };
 
 #endif

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -168,9 +168,6 @@ public:
   const uint16_t getRowLength()                 const;  // Get MCE header value
   const uint16_t getDataRate()                  const;  // Get MCE header value
 
-  // Get a pointer to a SmurfHeader object, to access the header information
-  SmurfHeader* getHeaderPtr();
-
   // Get a data value, at a specified index
   const avgdata_t getValue(std::size_t index) const;
 

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -150,10 +150,12 @@ public:
   SmurfHeader* getHeaderPtr();
 
   // Get a data value, at a specified index
-  const avgdata_t getData(std::size_t index) const;
+  const avgdata_t getValue(std::size_t index) const;
 
   // Get a byte from the header, at a specified index
   const uint8_t getHeaderByte(std::size_t index) const;
+
+
 
 private:
   std::size_t            headerLength;  // Header length (number of bytes)

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -152,6 +152,9 @@ public:
   // Get a data value, at a specified index
   const avgdata_t getValue(std::size_t index) const;
 
+  // Set a data value, at a specific index
+  void setValue(std::size_t index, avgdata_t value);
+
   // Get a byte from the header, at a specified index
   const uint8_t getHeaderByte(std::size_t index) const;
 

--- a/include/smurf_packet.h
+++ b/include/smurf_packet.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "common.h"
+#include "tes_bias_array.h"
 
 #include "smurf2mce.h"
 
@@ -137,14 +138,13 @@ public:
   // Get the total length of the packet in number of bytes
   const std::size_t getPacketLength()  const;
 
-  // Header function //
-  const uint8_t  getVersion()             const;  // Get protocol version
-  const uint8_t  getCrateID()             const;  // Get ATCA crate ID
-  const uint8_t  getSlotNumber()          const;  // Get ATCA slot number
-  const uint8_t  getTimingConfiguration() const;  // Get timing configuration
-  const uint32_t getNumberChannels()      const;  // Get number of channel in this packet
-
-  const uint32_t getTESDAC(std::size_t index) const;  // Get TES DAC values 16X 20 bit
+  // Header functions //
+  const uint8_t  getVersion()                 const;  // Get protocol version
+  const uint8_t  getCrateID()                 const;  // Get ATCA crate ID
+  const uint8_t  getSlotNumber()              const;  // Get ATCA slot number
+  const uint8_t  getTimingConfiguration()     const;  // Get timing configuration
+  const uint32_t getNumberChannels()          const;  // Get number of channel in this packet
+  const int32_t  getTESDAC(std::size_t index) const;  // Get TES DAC values 16X 20 bit
   const uint64_t getUnixTime()                const;  // Get 64 bit unix time nanoseconds
   const uint32_t getFluxRampIncrement()       const;  // Get signed 32 bit integer for increment
   const uint32_t getFluxRampOffset()          const;  // Get signed 32 it integer for offset
@@ -204,6 +204,7 @@ private:
   std::vector<uint8_t>   headerBuffer;  // Header buffer
   std::vector<avgdata_t> payloadBuffer; // Payload buffer
   SmurfHeader            header;        // Packet header object
+  TesBiasArray           tba;           // Tes Bias array object
 
   // Get a word from the header
   template<typename T>

--- a/include/smurf_processor.h
+++ b/include/smurf_processor.h
@@ -88,8 +88,13 @@ public:
   };
 
 
-  // Transmit thread. Here is where the method 'transmit' is called.
-  void transmitter();
+  // Transmit method. Will run in the pktTransmitterThread thread.
+  // Here is where the method 'transmit' is called.
+  void pktTansmitter();
+
+  // File writer method. Will run in the pktWriterThread thread.
+  // Here is where new SMuRF packet will be written to files.
+  void pktWriter();
 
   // This method is intended to be used to take SMuRF packet and send them to other
   // system.
@@ -111,11 +116,12 @@ private:
   //! Thread background
   void runThread();
 
-  DataBuffer          txBuffer;           // Buffer for SMuRF packet passed to the transmit thread.
-  boost::atomic<bool> runTxThread;        // Flag to indicate the TX thread to stop its loops
-  std::thread         transmitterThread;  // Thread where the SMuRF packet transmission will run
-  const size_t        pktReaderIndexTx;   // Data buffer reader index for the transmitter
-  const size_t        pktReaderIndexFile; // Data buffer reader index for the file writer
+  DataBuffer          txBuffer;             // Buffer for SMuRF packet passed to the transmit thread.
+  boost::atomic<bool> runTxThread;          // Flag to indicate the TX thread to stop its loops
+  const size_t        pktReaderIndexTx;     // Data buffer reader index for the transmitter
+  const size_t        pktReaderIndexFile;   // Data buffer reader index for the file writer
+  std::thread         pktTransmitterThread; // Thread where the SMuRF packet transmission will run
+  std::thread         pktWriterThread;      // Thread where the SMuRF packet file writer will run
 };
 
 #endif

--- a/include/smurf_processor.h
+++ b/include/smurf_processor.h
@@ -22,10 +22,6 @@
 namespace bp = boost::python;
 namespace ris = rogue::interfaces::stream;
 
-// Data type of the SMuRF packet buffer
-typedef uint8_t                     smurf_tx_data_t;    // TX buffer elements pointer-to type
-typedef DataBuffer<smurf_tx_data_t> smurf_tx_buffer_t;  // TX buffer type
-
 // SmurfProcessor "acceptframe" is called by python for each smurf frame
 // Smurf2mce definition should be in smurftcp.h, but doesn't work, not sure why
 class SmurfProcessor : public rogue::interfaces::stream::Slave
@@ -97,10 +93,10 @@ public:
 
   // This method is intended to be used to take SMuRF packet and send them to other
   // system.
-  // This method is called whenever a new SMuRF packet is ready, and a pointer to it is
-  // passed.
+  // This method is called whenever a new SMuRF packet is ready, and a SmurfPacket_RO object
+  // (which is a smart pointer to a read-only interface to a Smurf packer object) is passed.
   // It must be overwritten by the user application
-  virtual void transmit(smurf_tx_data_t* data) {};
+  virtual void transmit(SmurfPacket_RO sp) {};
 
   // Print statistic about the transmit methods
   void printTransmitStatistic() const;
@@ -115,7 +111,7 @@ private:
   //! Thread background
   void runThread();
 
-  smurf_tx_buffer_t   txBuffer;           // Buffer for SMuRF packet passed to the transmit thread.
+  DataBuffer          txBuffer;           // Buffer for SMuRF packet passed to the transmit thread.
   boost::atomic<bool> runTxThread;        // Flag to indicate the TX thread to stop its loops
   std::thread         transmitterThread;  // Thread where the SMuRF packet transmission will run
   int                 txPacketLossCnt;    // How many SMuRF packets could not be send to the transmit method

--- a/include/smurf_processor.h
+++ b/include/smurf_processor.h
@@ -114,7 +114,6 @@ private:
   DataBuffer          txBuffer;           // Buffer for SMuRF packet passed to the transmit thread.
   boost::atomic<bool> runTxThread;        // Flag to indicate the TX thread to stop its loops
   std::thread         transmitterThread;  // Thread where the SMuRF packet transmission will run
-  int                 txPacketLossCnt;    // How many SMuRF packets could not be send to the transmit method
   const size_t        pktReaderIndexTx;   // Data buffer reader index for the transmitter
   const size_t        pktReaderIndexFile; // Data buffer reader index for the file writer
 };

--- a/include/smurf_processor.h
+++ b/include/smurf_processor.h
@@ -115,6 +115,8 @@ private:
   boost::atomic<bool> runTxThread;        // Flag to indicate the TX thread to stop its loops
   std::thread         transmitterThread;  // Thread where the SMuRF packet transmission will run
   int                 txPacketLossCnt;    // How many SMuRF packets could not be send to the transmit method
+  const size_t        pktReaderIndexTx;   // Data buffer reader index for the transmitter
+  const size_t        pktReaderIndexFile; // Data buffer reader index for the file writer
 };
 
 #endif

--- a/include/smurftcp.h
+++ b/include/smurftcp.h
@@ -109,7 +109,7 @@ class SmurfDataFile // writes data file to disk
   uint fd; // file pointer
 
   SmurfDataFile(void);
-  uint write_file(uint8_t *header, uint header_bytes, avgdata_t *data, uint data_words, uint frames_to_write, char *fname, int name_mode,  bool disable);
+  uint write_file(SmurfPacket_RO packet, SmurfConfig *config);
   // writes to file, creates new if needded. return frames written, 0 new.
 };
 

--- a/include/tes_bias_array.h
+++ b/include/tes_bias_array.h
@@ -1,0 +1,73 @@
+#ifndef __TES_BIAS_ARRAY_H__
+#define __TES_BIAS_ARRAY_H__
+
+#include <stdexcept>
+#include <mutex>
+
+static const std::size_t TesBiasCount = 16;  // 16 Tes Bias values
+static const std::size_t TesBiasBufferSize = TesBiasCount * 20 / 8; // 16x 20-bit bytes
+
+// Class to handle TES bias array of values.
+class TesBiasArray
+{
+private:
+  // Pointer to the data buffer
+  uint8_t *pData;
+
+  // Mutex, to safetly access the data from different threads
+  std::mutex mut;
+
+  // Helper class to handler indexes of TES bias words
+  // TES bias are 20-bit words = 2.5 bytes
+  // 16x TES bias occupy 40 bytes, which are divided into 8 blocks of 2 words (5 bytes) each
+  // From each word index (0-15) a block number (0-7), and a word sub-index inside that block (0-1)
+  // is generated. For example, TES bias 6 and 7 are both located on block 3; with 6 at the first word
+  // and 7 on the second word inside that block.
+  class WordIndex
+  {
+  public:
+    WordIndex(std::size_t i) : index( i ), block( i / 2 ), word( i % 2 ) {};
+
+    std::size_t Index() const { return index; }; // 20-bit word index
+    std::size_t Block() const { return block; }; // 2-word block number
+    std::size_t Word()  const { return word;  }; // Word index inside the block
+
+    bool operator >= (std::size_t rhs) const { return index >= rhs; };
+
+  private:
+    std::size_t index; // 20-bit word index (0-15)
+    std::size_t block; // 2-word block index (0-7)
+    std::size_t word;  // Word index in the word block (0-1)
+  };
+
+  // Helper Union to access individual bytes of a word
+  typedef union
+  {
+    unsigned int word;
+    uint8_t byte[4];
+  } U;
+
+  // Helper Struct to sign extend 20-bit values
+  typedef struct
+  {
+    signed int word:20;
+  } S;
+
+public:
+ TesBiasArray(uint8_t *p);
+  ~TesBiasArray();
+
+  // Change the data pointer
+  void setPtr(uint8_t *p);
+
+  // Write a TES bias value
+  void setWord(const WordIndex& index, int value) const;
+
+  // Read a TES bias value
+  int getWord(const WordIndex& index) const;
+
+  // Method to the mutex
+  std::mutex* getMutex();
+};
+
+#endif

--- a/include/tes_bias_array.h
+++ b/include/tes_bias_array.h
@@ -61,10 +61,10 @@ public:
   void setPtr(uint8_t *p);
 
   // Write a TES bias value
-  void setWord(const WordIndex& index, int value) const;
+  void setWord(const WordIndex& index, int32_t value) const;
 
   // Read a TES bias value
-  int getWord(const WordIndex& index) const;
+  const int32_t getWord(const WordIndex& index) const;
 
   // Method to the mutex
   std::mutex* getMutex();

--- a/src/data_buffer.cpp
+++ b/src/data_buffer.cpp
@@ -57,8 +57,7 @@ SmurfPacket_RO DataBuffer::getReadPtr()
     }
 };
 
-// Call after a new packet is fully written into the buffer. The writing pointer will be move forward
-// to the next empty cell in the buffer.
+
 void DataBuffer::doneWriting()
 {
     // Move the iterator forward.
@@ -84,8 +83,6 @@ void DataBuffer::doneWriting()
     dataReady.notify_all();
 };
 
-// Call after a packet is fully processed. The reading pointer will be move forward to the
-// next cell in the buffer.
 void DataBuffer::doneReading()
 {
     // Move the iterator forward.

--- a/src/data_buffer.cpp
+++ b/src/data_buffer.cpp
@@ -1,23 +1,26 @@
 
 #include "data_buffer.h"
 
-DataBuffer::DataBuffer(std::size_t s)
+DataBuffer::DataBuffer(std::size_t bufSize, std::size_t numReaders)
 :
-size     ( s     ),
-full     ( false ),
-empty    ( true  ),
-writeCnt ( 0     ),
-readCnt  ( 0     ),
-WOFCnt   ( 0     ),
-ROFCnt   ( 0     )
+size          ( bufSize           ),
+numberReaders ( numReaders        ),
+full          ( numReaders, false ),
+empty         ( numReaders, true  ),
+writeCnt      ( 0                 ),
+readCnt       ( numReaders, 0     ),
+OWCnt         ( numReaders, 0     ),
+ROFCnt        ( numReaders, 0     )
 {
     for (std::size_t i(0); i < size; ++i)
         data.push_back(ISmurfPacket::create());
 
     writePtr = data.begin();
-    readPtr = data.begin();
 
-    printf("DataBuffer created of size %zu", size);
+    for (std::size_t i(0); i < numberReaders; ++i)
+        readPtr.push_back(data.begin());
+
+    printf("DataBuffer created of size %zu, and number of readers %zu", size, numberReaders);
     printf("DataBuffeV2.size =  %zu\n", data.size());
 };
 
@@ -28,32 +31,33 @@ DataBuffer::~DataBuffer()
 
 SmurfPacket DataBuffer::getWritePtr()
 {
-    // Verify if the buffer is full
-    if (full)
+
+    // If a reader's buffer is full, update its overwrite counter and move it
+    // read pointer forward
+    for(std::size_t i(0); i < numberReaders; ++i)
     {
-        // Increase the write overflow counter and throw exception
-        ++WOFCnt;
-        throw std::runtime_error("Trying to write when the buffer is full");
+        if (full.at(i))
+        {
+            ++OWCnt.at(i);
+            ++readPtr.at(i);
+        }
     }
-    else
-    {
-        return *writePtr;
-    }
+
+    return *writePtr;
 };
 
-// Get a pointer to the next available data packet, ready to be processed.
-SmurfPacket_RO DataBuffer::getReadPtr()
+SmurfPacket_RO DataBuffer::getReadPtr(std::size_t i)
 {
     // Verify is the buffer is empty
-    if (empty)
+    if (empty.at(i))
     {
         // Increase the read overflow counter and throw exception
-        ++ROFCnt;
+        ++ROFCnt.at(i);
         throw std::runtime_error("Trying to read when the buffer is empty");
     }
     else
     {
-        return *readPtr;
+        return *readPtr.at(i);
     }
 };
 
@@ -68,12 +72,15 @@ void DataBuffer::doneWriting()
     if (writePtr == data.end())
         writePtr = data.begin();
 
-    // Verify if the buffer is full.
-    if (writePtr == readPtr)
-        full = true;
+    // Verify if the buffer is full for each reader.
+    for (std::size_t i(0); i < numberReaders; ++i)
+    {
+        if (writePtr == readPtr.at(i))
+            full.at(i) = true;
+    }
 
     // The buffer is not empty after writing new data into it.
-    empty = false;
+    std::fill(empty.begin(), empty.end(), false);
 
     // Update write counter
     ++writeCnt;
@@ -83,56 +90,62 @@ void DataBuffer::doneWriting()
     dataReady.notify_all();
 };
 
-void DataBuffer::doneReading()
+void DataBuffer::doneReading(std::size_t i)
 {
     // Move the iterator forward.
-    ++readPtr;
+    ++readPtr.at(i);
 
     // Verify is we arrived to the end of the buffer.
     // If so, move the iterator back to the start.
-    if (readPtr == data.end())
-        readPtr = data.begin();
+    if (readPtr.at(i) == data.end())
+        readPtr.at(i) = data.begin();
 
-    // Verify if the buffer is empty.
-    if (readPtr == writePtr)
-        empty = true;
+    // Verify if the buffer is empty for each reader.
+    if (readPtr.at(i) == writePtr)
+        empty.at(i) = true;
 
-    // The buffer is not full after reading data from it.
-    full = false;
+    // The buffer is not full after reading data from it for that reader.
+    full.at(i) = false;
 
     // Update read counter
-    ++readCnt;
+    ++readCnt.at(i);
 };
 
-const bool DataBuffer::isEmpty() const
+const bool DataBuffer::isEmpty(std::size_t i) const
 {
-    return empty;
+    return empty.at(i);
 };
 
 const bool DataBuffer::isFull() const
 {
-    return full;
+    return ( std::find(full.begin(), full.end(), true) != full.end() );
 };
 
-const int DataBuffer::getROFCnt() const
+const std::size_t DataBuffer::getROFCnt(std::size_t i) const
 {
-    return ROFCnt;
+    return ROFCnt.at(i);
 };
 
-const int DataBuffer::getWOFCnt() const
+const std::size_t DataBuffer::getOWCnt(std::size_t i) const
 {
-    return WOFCnt;
+    return OWCnt.at(i);
 };
 
-void DataBuffer::clearOFCnts()
+void DataBuffer::clearCnts()
 {
-    ROFCnt = 0; WOFCnt =0;
+    std::fill(ROFCnt.begin(), ROFCnt.end(), 0);
+    std::fill(OWCnt.begin(), OWCnt.end(), 0);
 };
 
 const std::size_t DataBuffer::getSize() const
 {
     return size;
 };
+
+const std::size_t DataBuffer::getNumReaders() const
+{
+    return numberReaders;
+}
 
 std::mutex* DataBuffer::getMutex()
 {
@@ -151,10 +164,23 @@ void DataBuffer::printStatistic() const
     std::cout << "------------------------------"                                << std::endl;
     std::cout << "Buffer size                     : " << size                    << std::endl;
     std::cout << "Total write operations          : " << writeCnt                << std::endl;
-    std::cout << "Total read operations           : " << readCnt                 << std::endl;
-    std::cout << "Total write attempts while full : " << WOFCnt                  << std::endl;
-    std::cout << "Total read attempts while empty : " << ROFCnt                  << std::endl;
-    std::cout << "Buffer 'empty' flag             : " << std::boolalpha << empty << std::endl;
-    std::cout << "Buffer 'full' flag              : " << std::boolalpha << full  << std::endl;
-    std::cout << "------------------------------"                                << std::endl;
+
+    std::cout << "Total read operations           : ";
+    std::copy(readCnt.begin(), readCnt.end(), std::ostream_iterator<int>(std::cout, ", "));
+    std::cout << std::endl;
+
+    std::cout << "Total Overwrites                : ";
+    std::copy(OWCnt.begin(), OWCnt.end(), std::ostream_iterator<int>(std::cout, ", "));
+    std::cout << std::endl;
+
+    std::cout << "Total read attempts while empty : ";
+    std::copy(ROFCnt.begin(), ROFCnt.end(), std::ostream_iterator<int>(std::cout, ", "));
+    std::cout << std::endl;
+
+    std::cout << "Buffer 'empty' flag             : " << std::boolalpha;
+    std::copy(empty.begin(), empty.end(), std::ostream_iterator<bool>(std::cout, ", "));
+    std::cout << std::endl;
+
+    std::cout << "Buffer 'full' flag              : " << std::boolalpha << isFull()  << std::endl;
+    std::cout << "------------------------------"                                    << std::endl;
 };

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -644,7 +644,7 @@ inline void SmurfPacket::setHeaderWord(std::size_t offset, const T& value)
   *(reinterpret_cast<T*>(&headerBuffer.at(offset))) = value;
 }
 
-inline uint8_t setWordBit(uint8_t byte, std::size_t index, bool value)
+inline uint8_t SmurfPacket::setWordBit(uint8_t byte, std::size_t index, bool value)
 {
   if (index >= 8)
     throw std::runtime_error("Trying to set a byte bit out range.");

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -239,15 +239,16 @@ SmurfPacket::SmurfPacket()
 }
 
 SmurfPacket::SmurfPacket(uint8_t* h)
+:
+  SmurfPacket()
 {
-  SmurfPacket();
   copyHeader(h);
 }
 
 SmurfPacket::SmurfPacket(uint8_t* h, avgdata_t* d)
+:
+  SmurfPacket(h)
 {
-  SmurfPacket();
-  copyHeader(h);
   copyData(d);
 }
 

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -246,7 +246,7 @@ SmurfPacket::SmurfPacket(uint8_t* h)
 
 SmurfPacket::SmurfPacket(uint8_t* h, avgdata_t* d)
 {
-  SmurfPacket(h);
+  SmurfPacket();
   copyHeader(h);
   copyData(d);
 }

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -365,19 +365,19 @@ const uint8_t SmurfPacket::getControlField() const
 
 const bool SmurfPacket::getClearAverageBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x00);
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x01);
 }
 const bool SmurfPacket::getDisableStreamBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x01);
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x02);
 }
 const bool SmurfPacket::getDisableFileWriteBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x02);
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x04);
 }
 const bool SmurfPacket::getReadConfigEachCycleBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x04);
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x08);
 }
 const uint8_t SmurfPacket::getTestMode() const
 {

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -481,6 +481,12 @@ void SmurfPacket::setHeaderByte(std::size_t index, uint8_t value)
   headerBuffer.at(index) = value;
 }
 
+template <typename T>
+void SmurfPacket::setHeaderWord(std::size_t offset, const T& value)
+{
+  *(reinterpret_cast<T*>(&headerBuffer.at(offset))) = value;
+}
+
 ////////////////////////////////////////
 ////// - SmurfPacket definitions ///////
 ////////////////////////////////////////

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -278,7 +278,7 @@ void SmurfPacket::copyHeader(uint8_t* h)
 
 void SmurfPacket::copyData(avgdata_t* d)
 {
-  memcpy(payloadBuffer.data(), d, payloadLength);
+  memcpy(payloadBuffer.data(), d, payloadLength * sizeof(avgdata_t));
 }
 
 void SmurfPacket::writeToFile(uint fd) const

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -303,6 +303,11 @@ const avgdata_t SmurfPacket::getValue(std::size_t index) const
   return payloadBuffer.at(index);
 }
 
+void SmurfPacket::setValue(std::size_t index, avgdata_t value)
+{
+  payloadBuffer.at(index) = value;
+}
+
 const uint8_t SmurfPacket::getHeaderByte(std::size_t index) const
 {
   return headerBuffer.at(index);

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -223,9 +223,9 @@ uint SmurfHeader::average_control(int num_averages) // returns num averages when
 ////// - SmurfHeader definitions ///////
 ////////////////////////////////////////
 
-////////////////////////////////////////
+///////////////////////////////////////////
 ////// + SmurfPacket_RO definitions ///////
-////////////////////////////////////////
+///////////////////////////////////////////
 
 // Default constructor
 SmurfPacket_RO::SmurfPacket_RO()
@@ -242,20 +242,6 @@ SmurfPacket_RO::SmurfPacket_RO()
   std::cout << "Header length       = " << headerLength  << " bytes" << std::endl;
   std::cout << "Payload length      = " << payloadLength << " words" << std::endl;
   std::cout << "Total packet length = " << packetLength  << " bytes" << std::endl;
-}
-
-SmurfPacket_RO::SmurfPacket_RO(uint8_t* h)
-:
-  SmurfPacket_RO()
-{
-  copyHeader(h);
-}
-
-SmurfPacket_RO::SmurfPacket_RO(uint8_t* h, avgdata_t* d)
-:
-  SmurfPacket_RO(h)
-{
-  copyData(d);
 }
 
 SmurfPacket_RO::~SmurfPacket_RO()
@@ -415,16 +401,6 @@ const T SmurfPacket_RO::getHeaderWord(std::size_t offset) const
   return *(reinterpret_cast<const T*>(&headerBuffer.at(offset)));
 }
 
-void SmurfPacket_RO::copyHeader(uint8_t* h)
-{
-  memcpy(headerBuffer.data(), h, headerLength);
-}
-
-void SmurfPacket_RO::copyData(avgdata_t* d)
-{
-  memcpy(payloadBuffer.data(), d, payloadLength * sizeof(avgdata_t));
-}
-
 void SmurfPacket_RO::writeToFile(uint fd) const
 {
   write(fd, headerBuffer.data(), headerLength);
@@ -441,19 +417,9 @@ const avgdata_t SmurfPacket_RO::getValue(std::size_t index) const
   return payloadBuffer.at(index);
 }
 
-void SmurfPacket_RO::setValue(std::size_t index, avgdata_t value)
-{
-  payloadBuffer.at(index) = value;
-}
-
 const uint8_t SmurfPacket_RO::getHeaderByte(std::size_t index) const
 {
   return headerBuffer.at(index);
-}
-
-void SmurfPacket_RO::setHeaderByte(std::size_t index, uint8_t value)
-{
-  headerBuffer.at(index) = value;
 }
 
 void SmurfPacket_RO::getHeaderArray(uint8_t* h) const
@@ -466,8 +432,62 @@ void SmurfPacket_RO::getDataArray(avgdata_t* d) const
   memcpy(d, payloadBuffer.data(), payloadLength * sizeof(avgdata_t));
 }
 
-////////////////////////////////////////
+///////////////////////////////////////////
 ////// - SmurfPacket_RO definitions ///////
+///////////////////////////////////////////
+
+
+////////////////////////////////////////
+////// - SmurfPacket definitions ///////
+////////////////////////////////////////
+SmurfPacket::SmurfPacket()
+:
+  SmurfPacket_RO()
+{
+  std::cout << "SmurfPacket object created" << std::endl;
+}
+
+SmurfPacket::SmurfPacket(uint8_t* h)
+:
+  SmurfPacket()
+{
+  copyHeader(h);
+}
+
+SmurfPacket::SmurfPacket(uint8_t* h, avgdata_t* d)
+:
+  SmurfPacket(h)
+{
+  copyData(d);
+}
+
+SmurfPacket::~SmurfPacket()
+{
+  std::cout << "SmurfPacket object destroyed" << std::endl;
+}
+
+void SmurfPacket::copyHeader(uint8_t* h)
+{
+  memcpy(headerBuffer.data(), h, headerLength);
+}
+
+void SmurfPacket::copyData(avgdata_t* d)
+{
+  memcpy(payloadBuffer.data(), d, payloadLength * sizeof(avgdata_t));
+}
+
+void SmurfPacket::setValue(std::size_t index, avgdata_t value)
+{
+  payloadBuffer.at(index) = value;
+}
+
+void SmurfPacket::setHeaderByte(std::size_t index, uint8_t value)
+{
+  headerBuffer.at(index) = value;
+}
+
+////////////////////////////////////////
+////// - SmurfPacket definitions ///////
 ////////////////////////////////////////
 
 uint64_t pull_bit_field(uint8_t *ptr, uint offset, uint width)

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -224,11 +224,11 @@ uint SmurfHeader::average_control(int num_averages) // returns num averages when
 ////////////////////////////////////////
 
 ///////////////////////////////////////////
-////// + SmurfPacket_RO definitions ///////
+////// + ISmurfPacket_RO definitions ///////
 ///////////////////////////////////////////
 
 // Default constructor
-SmurfPacket_RO::SmurfPacket_RO()
+ISmurfPacket_RO::ISmurfPacket_RO()
 :
   headerLength(smurfheaderlength),
   payloadLength(smurfsamples),
@@ -238,174 +238,174 @@ SmurfPacket_RO::SmurfPacket_RO()
   header(headerBuffer.data()),
   tba(&headerBuffer.at(headerTESDACOffset))
 {
-  std::cout << "SmurfPacket_RO object created:" << std::endl;
+  std::cout << "ISmurfPacket_RO object created:" << std::endl;
   std::cout << "Header length       = " << headerLength  << " bytes" << std::endl;
   std::cout << "Payload length      = " << payloadLength << " words" << std::endl;
   std::cout << "Total packet length = " << packetLength  << " bytes" << std::endl;
 }
 
-SmurfPacket_RO::~SmurfPacket_RO()
+ISmurfPacket_RO::~ISmurfPacket_RO()
 {
-  std::cout << "SmurfPacket_RO object destroyed" << std::endl;
+  std::cout << "ISmurfPacket_RO object destroyed" << std::endl;
 }
 
-const std::size_t SmurfPacket_RO::getHeaderLength()  const
+const std::size_t ISmurfPacket_RO::getHeaderLength()  const
 {
   return headerLength;
 }
 
-const std::size_t SmurfPacket_RO::getPayloadLength() const
+const std::size_t ISmurfPacket_RO::getPayloadLength() const
 {
   return payloadLength;
 }
 
-const std::size_t SmurfPacket_RO::getPacketLength()  const
+const std::size_t ISmurfPacket_RO::getPacketLength()  const
 {
   return packetLength;
 }
 
-const uint8_t SmurfPacket_RO::getVersion() const
+const uint8_t ISmurfPacket_RO::getVersion() const
 {
   return getHeaderWord<uint8_t>(headerVersionOffset);
 }
 
-const uint8_t SmurfPacket_RO::getCrateID() const
+const uint8_t ISmurfPacket_RO::getCrateID() const
 {
   return getHeaderWord<uint8_t>(headerCrateIDOffset);
 }
 
-const uint8_t SmurfPacket_RO::getSlotNumber() const
+const uint8_t ISmurfPacket_RO::getSlotNumber() const
 {
   return getHeaderWord<uint8_t>(headerSlotNumberOffset);
 }
 
-const uint8_t SmurfPacket_RO::getTimingConfiguration() const
+const uint8_t ISmurfPacket_RO::getTimingConfiguration() const
 {
   return getHeaderWord<uint8_t>(headerTimingConfigurationOffset);
 }
 
-const uint32_t SmurfPacket_RO::getNumberChannels() const
+const uint32_t ISmurfPacket_RO::getNumberChannels() const
 {
   return getHeaderWord<uint32_t>(headerNumberChannelOffset);
 }
 
-const int32_t SmurfPacket_RO::getTESBias(std::size_t index) const
+const int32_t ISmurfPacket_RO::getTESBias(std::size_t index) const
 {
   return tba.getWord(index);
 }
 
-const uint64_t SmurfPacket_RO::getUnixTime() const
+const uint64_t ISmurfPacket_RO::getUnixTime() const
 {
   return getHeaderWord<uint64_t>(headerUnixTimeOffset);
 }
 
-const uint32_t SmurfPacket_RO::getFluxRampIncrement() const
+const uint32_t ISmurfPacket_RO::getFluxRampIncrement() const
 {
   return getHeaderWord<uint32_t>(headerFluxRampIncrementOffset);
 }
 
-const uint32_t SmurfPacket_RO::getFluxRampOffset() const
+const uint32_t ISmurfPacket_RO::getFluxRampOffset() const
 {
   return getHeaderWord<uint32_t>(headerFluxRampOffsetOffset);
 }
 
-const uint32_t SmurfPacket_RO::getCounter0() const
+const uint32_t ISmurfPacket_RO::getCounter0() const
 {
   return getHeaderWord<uint32_t>(headerCounter0Offset);
 }
 
-const uint32_t SmurfPacket_RO::getCounter1() const
+const uint32_t ISmurfPacket_RO::getCounter1() const
 {
   return getHeaderWord<uint32_t>(headerCounter1Offset);
 }
 
-const uint64_t SmurfPacket_RO::getCounter2() const
+const uint64_t ISmurfPacket_RO::getCounter2() const
 {
   return getHeaderWord<uint64_t>(headerCounter2Offset);
 }
 
-const uint32_t SmurfPacket_RO::getAveragingResetBits() const
+const uint32_t ISmurfPacket_RO::getAveragingResetBits() const
 {
   return getHeaderWord<uint32_t>(headerAveragingResetBitsOffset);
 }
 
-const uint32_t SmurfPacket_RO::getFrameCounter() const
+const uint32_t ISmurfPacket_RO::getFrameCounter() const
 {
   return getHeaderWord<uint32_t>(headerFrameCounterOffset);
 }
 
-const uint32_t SmurfPacket_RO::getTESRelaySetting() const
+const uint32_t ISmurfPacket_RO::getTESRelaySetting() const
 {
   return getHeaderWord<uint32_t>(headerTESRelaySettingOffset);
 }
 
-const uint64_t SmurfPacket_RO::getExternalTimeClock() const
+const uint64_t ISmurfPacket_RO::getExternalTimeClock() const
 {
   return getHeaderWord<uint64_t>(headerExternalTimeClockOffset);
 }
 
-const uint8_t SmurfPacket_RO::getControlField() const
+const uint8_t ISmurfPacket_RO::getControlField() const
 {
   return getHeaderWord<uint8_t>(headerControlFieldOffset);
 }
 
-const bool SmurfPacket_RO::getClearAverageBit() const
+const bool ISmurfPacket_RO::getClearAverageBit() const
 {
   return getWordBit(getHeaderWord<uint8_t>(headerControlFieldOffset), clearAvergaveBitOffset);
 }
 
-const bool SmurfPacket_RO::getDisableStreamBit() const
+const bool ISmurfPacket_RO::getDisableStreamBit() const
 {
   return getWordBit(getHeaderWord<uint8_t>(headerControlFieldOffset), disableStreamBitOffset);
 }
 
-const bool SmurfPacket_RO::getDisableFileWriteBit() const
+const bool ISmurfPacket_RO::getDisableFileWriteBit() const
 {
   return getWordBit(getHeaderWord<uint8_t>(headerControlFieldOffset), disableFileWriteBitOffset);
 }
 
-const bool SmurfPacket_RO::getReadConfigEachCycleBit() const
+const bool ISmurfPacket_RO::getReadConfigEachCycleBit() const
 {
   return getWordBit(getHeaderWord<uint8_t>(headerControlFieldOffset), readConfigEachCycleBitOffset);
 }
 
-const uint8_t SmurfPacket_RO::getTestMode() const
+const uint8_t ISmurfPacket_RO::getTestMode() const
 {
   return ((getHeaderWord<uint8_t>(headerControlFieldOffset) >> 4) & 0x0f);
 }
 
-const uint8_t SmurfPacket_RO::getTestParameters() const
+const uint8_t ISmurfPacket_RO::getTestParameters() const
 {
   return getHeaderWord<uint8_t>(headerTestParametersOffset);
 }
 
-const uint16_t SmurfPacket_RO::getNumberRows() const
+const uint16_t ISmurfPacket_RO::getNumberRows() const
 {
   return getHeaderWord<uint16_t>(headerNumberRowsOffset);
 }
 
-const uint16_t SmurfPacket_RO::getNumberRowsReported() const
+const uint16_t ISmurfPacket_RO::getNumberRowsReported() const
 {
   return getHeaderWord<uint16_t>(headerNumberRowsReportedOffset);
 }
 
-const uint16_t SmurfPacket_RO::getRowLength() const
+const uint16_t ISmurfPacket_RO::getRowLength() const
 {
   return getHeaderWord<uint16_t>(headerRowLengthOffset);
 }
 
-const uint16_t SmurfPacket_RO::getDataRate() const
+const uint16_t ISmurfPacket_RO::getDataRate() const
 {
   return getHeaderWord<uint16_t>(headerDataRateOffset);
 }
 
 template <typename T>
-const T SmurfPacket_RO::getHeaderWord(std::size_t offset) const
+const T ISmurfPacket_RO::getHeaderWord(std::size_t offset) const
 {
   return *(reinterpret_cast<const T*>(&headerBuffer.at(offset)));
 }
 
-const bool SmurfPacket_RO::getWordBit(uint8_t byte, std::size_t index) const
+const bool ISmurfPacket_RO::getWordBit(uint8_t byte, std::size_t index) const
 {
   if (index >= 8)
     throw std::runtime_error("Trying to get a bit with index > 8 from a byte");
@@ -413,186 +413,192 @@ const bool SmurfPacket_RO::getWordBit(uint8_t byte, std::size_t index) const
   return (byte & (0x01 << index));
 }
 
-void SmurfPacket_RO::writeToFile(uint fd) const
+void ISmurfPacket_RO::writeToFile(uint fd) const
 {
   write(fd, headerBuffer.data(), headerLength);
   write(fd, payloadBuffer.data(), payloadLength * sizeof(avgdata_t));
 }
 
-const avgdata_t SmurfPacket_RO::getValue(std::size_t index) const
+const avgdata_t ISmurfPacket_RO::getValue(std::size_t index) const
 {
   return payloadBuffer.at(index);
 }
 
-const uint8_t SmurfPacket_RO::getHeaderByte(std::size_t index) const
+const uint8_t ISmurfPacket_RO::getHeaderByte(std::size_t index) const
 {
   return headerBuffer.at(index);
 }
 
-void SmurfPacket_RO::getHeaderArray(uint8_t* h) const
+void ISmurfPacket_RO::getHeaderArray(uint8_t* h) const
 {
   memcpy(h, headerBuffer.data(), headerLength);
 }
 
-void SmurfPacket_RO::getDataArray(avgdata_t* d) const
+void ISmurfPacket_RO::getDataArray(avgdata_t* d) const
 {
   memcpy(d, payloadBuffer.data(), payloadLength * sizeof(avgdata_t));
 }
 
-///////////////////////////////////////////
-////// - SmurfPacket_RO definitions ///////
-///////////////////////////////////////////
-
-
-////////////////////////////////////////
-////// - SmurfPacket definitions ///////
-////////////////////////////////////////
-SmurfPacket::SmurfPacket()
-:
-  SmurfPacket_RO()
+SmurfPacket_RO ISmurfPacket_RO::create(const SmurfPacket& sp)
 {
-  std::cout << "SmurfPacket object created" << std::endl;
+  return sp;
+}
+///////////////////////////////////////////
+////// - ISmurfPacket_RO definitions ///////
+///////////////////////////////////////////
+
+
+////////////////////////////////////////
+////// - ISmurfPacket definitions ///////
+////////////////////////////////////////
+ISmurfPacket::ISmurfPacket()
+:
+  ISmurfPacket_RO()
+{
+  std::cout << "ISmurfPacket() object created" << std::endl;
 }
 
-SmurfPacket::SmurfPacket(uint8_t* h)
+ISmurfPacket::ISmurfPacket(uint8_t* h)
 :
-  SmurfPacket()
+  ISmurfPacket()
 {
+  std::cout << "ISmurfPacket(uint8_t* h) object created" << std::endl;
   copyHeader(h);
 }
 
-SmurfPacket::SmurfPacket(uint8_t* h, avgdata_t* d)
+ISmurfPacket::ISmurfPacket(uint8_t* h, avgdata_t* d)
 :
-  SmurfPacket(h)
+  ISmurfPacket(h)
 {
+  std::cout << "ISmurfPacket(uint8_t* h, avgdata_t* d) object created" << std::endl;
   copyData(d);
 }
 
-SmurfPacket::~SmurfPacket()
+ISmurfPacket::~ISmurfPacket()
 {
-  std::cout << "SmurfPacket object destroyed" << std::endl;
+  std::cout << "ISmurfPacket object destroyed" << std::endl;
 }
 
-void SmurfPacket::copyHeader(uint8_t* h)
+void ISmurfPacket::copyHeader(uint8_t* h)
 {
   memcpy(headerBuffer.data(), h, headerLength);
 }
 
-void SmurfPacket::copyData(avgdata_t* d)
+void ISmurfPacket::copyData(avgdata_t* d)
 {
   memcpy(payloadBuffer.data(), d, payloadLength * sizeof(avgdata_t));
 }
 
-void SmurfPacket::setVersion(uint8_t value)
+void ISmurfPacket::setVersion(uint8_t value)
 {
   setHeaderWord<uint8_t>(headerVersionOffset, value);
 }
 
-void SmurfPacket::setCrateID(uint8_t value)
+void ISmurfPacket::setCrateID(uint8_t value)
 {
   setHeaderWord<uint8_t>(headerCrateIDOffset, value);
 }
 
-void SmurfPacket::setSlotNumber(uint8_t value)
+void ISmurfPacket::setSlotNumber(uint8_t value)
 {
   setHeaderWord<uint8_t>(headerSlotNumberOffset, value);
 }
 
-void  SmurfPacket::setTimingConfiguration(uint8_t value)
+void  ISmurfPacket::setTimingConfiguration(uint8_t value)
 {
   setHeaderWord<uint8_t>(headerTimingConfigurationOffset, value);
 }
 
-void SmurfPacket::setNumberChannels(uint32_t value)
+void ISmurfPacket::setNumberChannels(uint32_t value)
 {
   setHeaderWord<uint32_t>(headerNumberChannelOffset, value);
 }
 
-void  SmurfPacket::setTESBias(std::size_t index, int32_t value)
+void  ISmurfPacket::setTESBias(std::size_t index, int32_t value)
 {
   tba.setWord(index, value);
 }
 
-void SmurfPacket::setUnixTime(uint64_t value)
+void ISmurfPacket::setUnixTime(uint64_t value)
 {
   setHeaderWord<uint64_t>(headerUnixTimeOffset, value);
 }
 
-void SmurfPacket::setFluxRampIncrement(uint32_t value)
+void ISmurfPacket::setFluxRampIncrement(uint32_t value)
 {
   setHeaderWord<uint32_t>(headerFluxRampIncrementOffset, value);
 }
 
-void SmurfPacket::setFluxRampOffset(uint32_t value)
+void ISmurfPacket::setFluxRampOffset(uint32_t value)
 {
   setHeaderWord<uint32_t>(headerFluxRampOffsetOffset, value);
 }
 
-void SmurfPacket::setCounter0(uint32_t value)
+void ISmurfPacket::setCounter0(uint32_t value)
 {
   setHeaderWord<uint32_t>(headerCounter0Offset, value);
 }
 
-void SmurfPacket::setCounter1(uint32_t value)
+void ISmurfPacket::setCounter1(uint32_t value)
 {
   setHeaderWord<uint32_t>(headerCounter1Offset, value);
 }
 
-void SmurfPacket::setCounter2(uint64_t value)
+void ISmurfPacket::setCounter2(uint64_t value)
 {
   setHeaderWord<uint64_t>(headerCounter2Offset, value);
 }
 
-void SmurfPacket::setAveragingResetBits(uint32_t value)
+void ISmurfPacket::setAveragingResetBits(uint32_t value)
 {
   setHeaderWord<uint32_t>(headerAveragingResetBitsOffset, value);
 }
 
-void SmurfPacket::setFrameCounter(uint32_t value)
+void ISmurfPacket::setFrameCounter(uint32_t value)
 {
   setHeaderWord<uint32_t>(headerFrameCounterOffset, value);
 }
 
-void SmurfPacket::setTESRelaySetting(uint32_t value)
+void ISmurfPacket::setTESRelaySetting(uint32_t value)
 {
   setHeaderWord<uint32_t>(headerTESRelaySettingOffset, value);
 }
 
-void SmurfPacket::setExternalTimeClock(uint64_t value)
+void ISmurfPacket::setExternalTimeClock(uint64_t value)
 {
   setHeaderWord<uint64_t>(headerExternalTimeClockOffset, value);
 }
 
-void SmurfPacket::setControlField(uint8_t value)
+void ISmurfPacket::setControlField(uint8_t value)
 {
   setHeaderWord<uint8_t>(headerControlFieldOffset, value);
 }
 
-void SmurfPacket::setClearAverageBit(bool value)
+void ISmurfPacket::setClearAverageBit(bool value)
 {
   setHeaderWord<uint8_t>(headerControlFieldOffset, \
     setWordBit(getControlField(), clearAvergaveBitOffset, value));
 }
 
-void SmurfPacket::setDisableStreamBit(bool value)
+void ISmurfPacket::setDisableStreamBit(bool value)
 {
   setHeaderWord<uint8_t>(headerControlFieldOffset, \
     setWordBit(getControlField(), disableStreamBitOffset, value));
 }
 
-void SmurfPacket::setDisableFileWriteBit(bool value)
+void ISmurfPacket::setDisableFileWriteBit(bool value)
 {
   setHeaderWord<uint8_t>(headerControlFieldOffset, \
     setWordBit(getControlField(), disableFileWriteBitOffset, value));
 }
 
-void SmurfPacket::setReadConfigEachCycleBit(bool value)
+void ISmurfPacket::setReadConfigEachCycleBit(bool value)
 {
   setHeaderWord<uint8_t>(headerControlFieldOffset, \
     setWordBit(getControlField(), readConfigEachCycleBitOffset, value));
 }
 
-void SmurfPacket::setTestMode(uint8_t value)
+void ISmurfPacket::setTestMode(uint8_t value)
 {
   uint8_t u8 = getControlField();
 
@@ -602,49 +608,49 @@ void SmurfPacket::setTestMode(uint8_t value)
   setHeaderWord<uint8_t>(headerControlFieldOffset, u8);
 }
 
-void SmurfPacket::setTestParameters(uint8_t value)
+void ISmurfPacket::setTestParameters(uint8_t value)
 {
   setHeaderWord<uint8_t>(headerTestParametersOffset, value);
 }
 
-void SmurfPacket::setNumberRows(uint16_t value)
+void ISmurfPacket::setNumberRows(uint16_t value)
 {
   setHeaderWord<uint16_t>(headerNumberRowsOffset, value);
 }
 
-void SmurfPacket::setNumberRowsReported(uint16_t value)
+void ISmurfPacket::setNumberRowsReported(uint16_t value)
 {
   setHeaderWord<uint16_t>(headerNumberRowsReportedOffset, value);
 }
 
-void SmurfPacket::setRowLength(uint16_t value)
+void ISmurfPacket::setRowLength(uint16_t value)
 {
   setHeaderWord<uint16_t>(headerRowLengthOffset, value);
 }
 
-void SmurfPacket::setDataRate(uint16_t value)
+void ISmurfPacket::setDataRate(uint16_t value)
 {
   setHeaderWord<uint16_t>(headerDataRateOffset, value);
 }
 
 
-void SmurfPacket::setHeaderByte(std::size_t index, uint8_t value)
+void ISmurfPacket::setHeaderByte(std::size_t index, uint8_t value)
 {
   headerBuffer.at(index) = value;
 }
 
-void SmurfPacket::setValue(std::size_t index, avgdata_t value)
+void ISmurfPacket::setValue(std::size_t index, avgdata_t value)
 {
   payloadBuffer.at(index) = value;
 }
 
 template <typename T>
-void SmurfPacket::setHeaderWord(std::size_t offset, const T& value)
+void ISmurfPacket::setHeaderWord(std::size_t offset, const T& value)
 {
   *(reinterpret_cast<T*>(&headerBuffer.at(offset))) = value;
 }
 
-uint8_t SmurfPacket::setWordBit(uint8_t byte, std::size_t index, bool value)
+uint8_t ISmurfPacket::setWordBit(uint8_t byte, std::size_t index, bool value)
 {
   if (index >= 8)
     throw std::runtime_error("Trying to set a byte bit out range.");
@@ -657,8 +663,23 @@ uint8_t SmurfPacket::setWordBit(uint8_t byte, std::size_t index, bool value)
   return byte;
 }
 
+SmurfPacket ISmurfPacket::create()
+{
+  return std::make_shared<ISmurfPacket>();
+}
+
+SmurfPacket ISmurfPacket::create(uint8_t* h)
+{
+  return std::make_shared<ISmurfPacket>(h);
+}
+
+SmurfPacket ISmurfPacket::create(uint8_t* h, avgdata_t* d)
+{
+  return std::make_shared<ISmurfPacket>(h,d);
+}
+
 ////////////////////////////////////////
-////// - SmurfPacket definitions ///////
+////// - ISmurfPacket definitions ///////
 ////////////////////////////////////////
 
 uint64_t pull_bit_field(uint8_t *ptr, uint offset, uint width)

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -351,24 +351,24 @@ const uint8_t SmurfPacket_RO::getControlField() const
 
 const bool SmurfPacket_RO::getClearAverageBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & \
-    (0x01 << clearAvergaveBitOffset));
+  return getWordBit(getHeaderWord<uint8_t>(headerControlFieldOffset), clearAvergaveBitOffset);
 }
+
 const bool SmurfPacket_RO::getDisableStreamBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & \
-    (0x01 << disableStreamBitOffset));
+  return getWordBit(getHeaderWord<uint8_t>(headerControlFieldOffset), disableStreamBitOffset);
 }
+
 const bool SmurfPacket_RO::getDisableFileWriteBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & \
-    (0x01 << disableFileWriteBitOffset));
+  return getWordBit(getHeaderWord<uint8_t>(headerControlFieldOffset), disableFileWriteBitOffset);
 }
+
 const bool SmurfPacket_RO::getReadConfigEachCycleBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & \
-    (0x01 << readConfigEachCycleBitOffset));
+  return getWordBit(getHeaderWord<uint8_t>(headerControlFieldOffset), readConfigEachCycleBitOffset);
 }
+
 const uint8_t SmurfPacket_RO::getTestMode() const
 {
   return ((getHeaderWord<uint8_t>(headerControlFieldOffset) >> 4) & 0x0f);
@@ -403,6 +403,14 @@ template <typename T>
 const T SmurfPacket_RO::getHeaderWord(std::size_t offset) const
 {
   return *(reinterpret_cast<const T*>(&headerBuffer.at(offset)));
+}
+
+const bool SmurfPacket_RO::getWordBit(uint8_t byte, std::size_t index) const
+{
+  if (index >= 8)
+    throw std::runtime_error("Trying to get a bit with index > 8 from a byte");
+
+  return (byte & (0x01 << index));
 }
 
 void SmurfPacket_RO::writeToFile(uint fd) const

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -400,12 +400,12 @@ const uint16_t SmurfPacket_RO::getDataRate() const
 }
 
 template <typename T>
-inline const T SmurfPacket_RO::getHeaderWord(std::size_t offset) const
+const T SmurfPacket_RO::getHeaderWord(std::size_t offset) const
 {
   return *(reinterpret_cast<const T*>(&headerBuffer.at(offset)));
 }
 
-inline const bool SmurfPacket_RO::getWordBit(uint8_t byte, std::size_t index) const
+const bool SmurfPacket_RO::getWordBit(uint8_t byte, std::size_t index) const
 {
   if (index >= 8)
     throw std::runtime_error("Trying to get a bit with index > 8 from a byte");
@@ -639,12 +639,12 @@ void SmurfPacket::setValue(std::size_t index, avgdata_t value)
 }
 
 template <typename T>
-inline void SmurfPacket::setHeaderWord(std::size_t offset, const T& value)
+void SmurfPacket::setHeaderWord(std::size_t offset, const T& value)
 {
   *(reinterpret_cast<T*>(&headerBuffer.at(offset))) = value;
 }
 
-inline uint8_t SmurfPacket::setWordBit(uint8_t byte, std::size_t index, bool value)
+uint8_t SmurfPacket::setWordBit(uint8_t byte, std::size_t index, bool value)
 {
   if (index >= 8)
     throw std::runtime_error("Trying to set a byte bit out range.");

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -471,20 +471,178 @@ void SmurfPacket::copyData(avgdata_t* d)
   memcpy(payloadBuffer.data(), d, payloadLength * sizeof(avgdata_t));
 }
 
-void SmurfPacket::setValue(std::size_t index, avgdata_t value)
+void SmurfPacket::setVersion(uint8_t value)
 {
-  payloadBuffer.at(index) = value;
+  setHeaderWord<uint8_t>(headerVersionOffset, value);
 }
+
+void SmurfPacket::setCrateID(uint8_t value)
+{
+  setHeaderWord<uint8_t>(headerCrateIDOffset, value);
+}
+
+void SmurfPacket::setSlotNumber(uint8_t value)
+{
+  setHeaderWord<uint8_t>(headerSlotNumberOffset, value);
+}
+
+void  SmurfPacket::setTimingConfiguration(uint8_t value)
+{
+  setHeaderWord<uint8_t>(headerTimingConfigurationOffset, value);
+}
+
+void SmurfPacket::setNumberChannels(uint32_t value)
+{
+  setHeaderWord<uint32_t>(headerNumberChannelOffset, value);
+}
+
+void  SmurfPacket::setTESBias(std::size_t index, int32_t value)
+{
+  tba.setWord(index, value);
+}
+
+void SmurfPacket::setUnixTime(uint64_t value)
+{
+  setHeaderWord<uint64_t>(headerUnixTimeOffset, value);
+}
+
+void SmurfPacket::setFluxRampIncrement(uint32_t value)
+{
+  setHeaderWord<uint32_t>(headerFluxRampIncrementOffset, value);
+}
+
+void SmurfPacket::setFluxRampOffset(uint32_t value)
+{
+  setHeaderWord<uint32_t>(headerFluxRampOffsetOffset, value);
+}
+
+void SmurfPacket::setCounter0(uint32_t value)
+{
+  setHeaderWord<uint32_t>(headerCounter0Offset, value);
+}
+
+void SmurfPacket::setCounter1(uint32_t value)
+{
+  setHeaderWord<uint32_t>(headerCounter1Offset, value);
+}
+
+void SmurfPacket::setCounter2(uint64_t value)
+{
+  setHeaderWord<uint64_t>(headerCounter2Offset, value);
+}
+
+void SmurfPacket::setAveragingResetBits(uint32_t value)
+{
+  setHeaderWord<uint32_t>(headerAveragingResetBitsOffset, value);
+}
+
+void SmurfPacket::setFrameCounter(uint32_t value)
+{
+  setHeaderWord<uint32_t>(headerFrameCounterOffset, value);
+}
+
+void SmurfPacket::setTESRelaySetting(uint32_t value)
+{
+  setHeaderWord<uint32_t>(headerTESRelaySettingOffset, value);
+}
+
+void SmurfPacket::setExternalTimeClock(uint64_t value)
+{
+  setHeaderWord<uint64_t>(headerExternalTimeClockOffset, value);
+}
+
+void SmurfPacket::setControlField(uint8_t value)
+{
+  setHeaderWord<uint8_t>(headerControlFieldOffset, value);
+}
+
+void SmurfPacket::setClearAverageBit(bool value)
+{
+  setHeaderWord<uint8_t>(headerControlFieldOffset, \
+    setWordBit(getControlField(), 0, value));
+}
+
+void SmurfPacket::setDisableStreamBit(bool value)
+{
+  setHeaderWord<uint8_t>(headerControlFieldOffset, \
+    setWordBit(getControlField(), 1, value));
+}
+
+void SmurfPacket::setDisableFileWriteBit(bool value)
+{
+  setHeaderWord<uint8_t>(headerControlFieldOffset, \
+    setWordBit(getControlField(), 2, value));
+}
+
+void SmurfPacket::setReadConfigEachCycleBit(bool value)
+{
+  setHeaderWord<uint8_t>(headerControlFieldOffset, \
+    setWordBit(getControlField(), 3, value));
+}
+
+void SmurfPacket::setTestMode(uint8_t value)
+{
+  uint8_t u8 = getControlField();
+
+  u8 &= 0x0f;
+  u8 |= ( (value << 4 ) & 0xf0 );
+
+  setHeaderWord<uint8_t>(headerControlFieldOffset, u8);
+}
+
+void SmurfPacket::setTestParameters(uint8_t value)
+{
+  setHeaderWord<uint8_t>(headerTestParametersOffset, value);
+}
+
+void SmurfPacket::setNumberRows(uint16_t value)
+{
+  setHeaderWord<uint16_t>(headerNumberRowsOffset, value);
+}
+
+void SmurfPacket::setNumberRowsReported(uint16_t value)
+{
+  setHeaderWord<uint16_t>(headerNumberRowsReportedOffset, value);
+}
+
+void SmurfPacket::setRowLength(uint16_t value)
+{
+  setHeaderWord<uint16_t>(headerRowLengthOffset, value);
+}
+
+void SmurfPacket::setDataRate(uint16_t value)
+{
+  setHeaderWord<uint16_t>(headerDataRateOffset, value);
+}
+
 
 void SmurfPacket::setHeaderByte(std::size_t index, uint8_t value)
 {
   headerBuffer.at(index) = value;
 }
 
+void SmurfPacket::setValue(std::size_t index, avgdata_t value)
+{
+  payloadBuffer.at(index) = value;
+}
+
 template <typename T>
 void SmurfPacket::setHeaderWord(std::size_t offset, const T& value)
 {
   *(reinterpret_cast<T*>(&headerBuffer.at(offset))) = value;
+}
+
+uint8_t setWordBit(uint8_t byte, std::size_t index, bool value)
+{
+  if (index >= 8)
+    throw std::runtime_error("Trying to set a byte bit out range.");
+
+  if (value)
+    byte |= (0x01 << index);
+  else
+    byte &= ~(0x01 << index);
+
+  return byte;
 }
 
 ////////////////////////////////////////

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -407,11 +407,6 @@ void SmurfPacket_RO::writeToFile(uint fd) const
   write(fd, payloadBuffer.data(), payloadLength * sizeof(avgdata_t));
 }
 
-SmurfHeader* SmurfPacket_RO::getHeaderPtr()
-{
-  return &header;
-}
-
 const avgdata_t SmurfPacket_RO::getValue(std::size_t index) const
 {
   return payloadBuffer.at(index);

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -313,6 +313,11 @@ const uint8_t SmurfPacket::getHeaderByte(std::size_t index) const
   return headerBuffer.at(index);
 }
 
+void SmurfPacket::setHeaderByte(std::size_t index, uint8_t value)
+{
+  headerBuffer.at(index) = value;
+}
+
 ////////////////////////////////////////
 ////// - SmurfPacket definitions ///////
 ////////////////////////////////////////

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -400,12 +400,12 @@ const uint16_t SmurfPacket_RO::getDataRate() const
 }
 
 template <typename T>
-const T SmurfPacket_RO::getHeaderWord(std::size_t offset) const
+inline const T SmurfPacket_RO::getHeaderWord(std::size_t offset) const
 {
   return *(reinterpret_cast<const T*>(&headerBuffer.at(offset)));
 }
 
-const bool SmurfPacket_RO::getWordBit(uint8_t byte, std::size_t index) const
+inline const bool SmurfPacket_RO::getWordBit(uint8_t byte, std::size_t index) const
 {
   if (index >= 8)
     throw std::runtime_error("Trying to get a bit with index > 8 from a byte");
@@ -639,12 +639,12 @@ void SmurfPacket::setValue(std::size_t index, avgdata_t value)
 }
 
 template <typename T>
-void SmurfPacket::setHeaderWord(std::size_t offset, const T& value)
+inline void SmurfPacket::setHeaderWord(std::size_t offset, const T& value)
 {
   *(reinterpret_cast<T*>(&headerBuffer.at(offset))) = value;
 }
 
-uint8_t setWordBit(uint8_t byte, std::size_t index, bool value)
+inline uint8_t setWordBit(uint8_t byte, std::size_t index, bool value)
 {
   if (index >= 8)
     throw std::runtime_error("Trying to set a byte bit out range.");

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -21,6 +21,13 @@ SmurfHeader::SmurfHeader()
   unix_dtime = 0;
 }
 
+SmurfHeader::SmurfHeader(uint8_t *buffer)
+:
+  SmurfHeader()
+{
+  copy_header(buffer);
+}
+
 void SmurfHeader::copy_header(uint8_t *buffer)
 {
   header = buffer;  // just move the pointer
@@ -228,10 +235,8 @@ SmurfPacket::SmurfPacket()
   packetLength(smurfheaderlength + smurfsamples * sizeof(avgdata_t)),
   headerBuffer(smurfheaderlength),
   payloadBuffer(smurfsamples),
-  header()
+  header(headerBuffer.data())
 {
-  // Update the SmurfHeader internal pointer to the header buffer
-  header.copy_header(headerBuffer.data());
   std::cout << "SmurfPacket object created:" << std::endl;
   std::cout << "Header length       = " << headerLength  << " bytes" << std::endl;
   std::cout << "Payload length      = " << payloadLength << " words" << std::endl;

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -277,6 +277,31 @@ const std::size_t SmurfPacket::getPacketLength()  const
   return packetLength;
 }
 
+const uint8_t SmurfPacket::getVersion() const
+{
+  return headerBuffer.at(0);
+}
+
+const uint8_t SmurfPacket::getCrateID() const
+{
+  return headerBuffer.at(1);
+}
+
+const uint8_t SmurfPacket::getSlotNumber() const
+{
+  return headerBuffer.at(2);
+}
+
+const uint8_t SmurfPacket::getTimingConfiguration() const
+{
+  return headerBuffer.at(3);
+}
+
+const uint32_t SmurfPacket::getNumberChannels() const
+{
+  return *(reinterpret_cast<const uint32_t*>(&headerBuffer.at(4)));
+}
+
 void SmurfPacket::copyHeader(uint8_t* h)
 {
   memcpy(headerBuffer.data(), h, headerLength);

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -318,6 +318,16 @@ void SmurfPacket::setHeaderByte(std::size_t index, uint8_t value)
   headerBuffer.at(index) = value;
 }
 
+void SmurfPacket::getHeaderArray(uint8_t* h) const
+{
+  memcpy(h, headerBuffer.data(), headerLength);
+}
+
+void SmurfPacket::getDataArray(avgdata_t* d) const
+{
+  memcpy(d, payloadBuffer.data(), payloadLength * sizeof(avgdata_t));
+}
+
 ////////////////////////////////////////
 ////// - SmurfPacket definitions ///////
 ////////////////////////////////////////

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -303,7 +303,7 @@ const uint32_t SmurfPacket::getNumberChannels() const
   return getHeaderWord<uint32_t>(headerNumberChannelOffset);
 }
 
-const int32_t SmurfPacket::getTESDAC(std::size_t index) const
+const int32_t SmurfPacket::getTESBias(std::size_t index) const
 {
   return tba.getWord(index);
 }

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -279,27 +279,128 @@ const std::size_t SmurfPacket::getPacketLength()  const
 
 const uint8_t SmurfPacket::getVersion() const
 {
-  return getHeaderWord<uint8_t>(0);
+  return getHeaderWord<uint8_t>(headerVersionOffset);
 }
 
 const uint8_t SmurfPacket::getCrateID() const
 {
-  return getHeaderWord<uint8_t>(1);
+  return getHeaderWord<uint8_t>(headerCrateIDOffset);
 }
 
 const uint8_t SmurfPacket::getSlotNumber() const
 {
-  return getHeaderWord<uint8_t>(2);
+  return getHeaderWord<uint8_t>(headerSlotNumberOffset);
 }
 
 const uint8_t SmurfPacket::getTimingConfiguration() const
 {
-  return getHeaderWord<uint8_t>(3);
+  return getHeaderWord<uint8_t>(headerTimingConfigurationOffset);
 }
 
 const uint32_t SmurfPacket::getNumberChannels() const
 {
-  return getHeaderWord<uint32_t>(4);
+  return getHeaderWord<uint32_t>(headerNumberChannelOffset);
+}
+
+const uint64_t SmurfPacket::getUnixTime() const
+{
+  return getHeaderWord<uint64_t>(headerUnixTimeOffset);
+}
+
+const uint32_t SmurfPacket::getFluxRampIncrement() const
+{
+  return getHeaderWord<uint32_t>(headerFluxRampIncrementOffset);
+}
+
+const uint32_t SmurfPacket::getFluxRampOffset() const
+{
+  return getHeaderWord<uint32_t>(headerFluxRampOffsetOffset);
+}
+
+const uint32_t SmurfPacket::getCounter0() const
+{
+  return getHeaderWord<uint32_t>(headerCounter0Offset);
+}
+
+const uint32_t SmurfPacket::getCounter1() const
+{
+  return getHeaderWord<uint32_t>(headerCounter1Offset);
+}
+
+const uint64_t SmurfPacket::getCounter2() const
+{
+  return getHeaderWord<uint64_t>(headerCounter2Offset);
+}
+
+const uint32_t SmurfPacket::getAveragingResetBits() const
+{
+  return getHeaderWord<uint32_t>(headerAveragingResetBitsOffset);
+}
+
+const uint32_t SmurfPacket::getFrameCounter() const
+{
+  return getHeaderWord<uint32_t>(headerFrameCounterOffset);
+}
+
+const uint32_t SmurfPacket::getTESRelaySetting() const
+{
+  return getHeaderWord<uint32_t>(headerTESRelaySettingOffset);
+}
+
+const uint64_t SmurfPacket::getExternalTimeClock() const
+{
+  return getHeaderWord<uint64_t>(headerExternalTimeClockOffset);
+}
+
+const uint8_t SmurfPacket::getControlField() const
+{
+  return getHeaderWord<uint8_t>(headerControlFieldOffset);
+}
+
+const bool SmurfPacket::getClearAverageBit() const
+{
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x00);
+}
+const bool SmurfPacket::getDisableStreamBit() const
+{
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x01);
+}
+const bool SmurfPacket::getDisableFileWriteBit() const
+{
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x02);
+}
+const bool SmurfPacket::getReadConfigEachCycleBit() const
+{
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x04);
+}
+const uint8_t SmurfPacket::getTestMode() const
+{
+  return ((getHeaderWord<uint8_t>(headerControlFieldOffset) >> 4) & 0x0f);
+}
+
+const uint8_t SmurfPacket::getTestParameters() const
+{
+  return getHeaderWord<uint8_t>(headerTestParametersOffset);
+}
+
+const uint16_t SmurfPacket::getNumberRows() const
+{
+  return getHeaderWord<uint16_t>(headerNumberRowsOffset);
+}
+
+const uint16_t SmurfPacket::getNumberRowsReported() const
+{
+  return getHeaderWord<uint16_t>(headerNumberRowsReportedOffset);
+}
+
+const uint16_t SmurfPacket::getRowLength() const
+{
+  return getHeaderWord<uint16_t>(headerRowLengthOffset);
+}
+
+const uint16_t SmurfPacket::getDataRate() const
+{
+  return getHeaderWord<uint16_t>(headerDataRateOffset);
 }
 
 template <typename T>

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -351,19 +351,23 @@ const uint8_t SmurfPacket_RO::getControlField() const
 
 const bool SmurfPacket_RO::getClearAverageBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x01);
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & \
+    (0x01 << clearAvergaveBitOffset));
 }
 const bool SmurfPacket_RO::getDisableStreamBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x02);
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & \
+    (0x01 << disableStreamBitOffset));
 }
 const bool SmurfPacket_RO::getDisableFileWriteBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x04);
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & \
+    (0x01 << disableFileWriteBitOffset));
 }
 const bool SmurfPacket_RO::getReadConfigEachCycleBit() const
 {
-  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x08);
+  return (getHeaderWord<uint8_t>(headerControlFieldOffset) & \
+    (0x01 << readConfigEachCycleBitOffset));
 }
 const uint8_t SmurfPacket_RO::getTestMode() const
 {
@@ -559,25 +563,25 @@ void SmurfPacket::setControlField(uint8_t value)
 void SmurfPacket::setClearAverageBit(bool value)
 {
   setHeaderWord<uint8_t>(headerControlFieldOffset, \
-    setWordBit(getControlField(), 0, value));
+    setWordBit(getControlField(), clearAvergaveBitOffset, value));
 }
 
 void SmurfPacket::setDisableStreamBit(bool value)
 {
   setHeaderWord<uint8_t>(headerControlFieldOffset, \
-    setWordBit(getControlField(), 1, value));
+    setWordBit(getControlField(), disableStreamBitOffset, value));
 }
 
 void SmurfPacket::setDisableFileWriteBit(bool value)
 {
   setHeaderWord<uint8_t>(headerControlFieldOffset, \
-    setWordBit(getControlField(), 2, value));
+    setWordBit(getControlField(), disableFileWriteBitOffset, value));
 }
 
 void SmurfPacket::setReadConfigEachCycleBit(bool value)
 {
   setHeaderWord<uint8_t>(headerControlFieldOffset, \
-    setWordBit(getControlField(), 3, value));
+    setWordBit(getControlField(), readConfigEachCycleBitOffset, value));
 }
 
 void SmurfPacket::setTestMode(uint8_t value)

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -279,27 +279,33 @@ const std::size_t SmurfPacket::getPacketLength()  const
 
 const uint8_t SmurfPacket::getVersion() const
 {
-  return headerBuffer.at(0);
+  return getHeaderWord<uint8_t>(0);
 }
 
 const uint8_t SmurfPacket::getCrateID() const
 {
-  return headerBuffer.at(1);
+  return getHeaderWord<uint8_t>(1);
 }
 
 const uint8_t SmurfPacket::getSlotNumber() const
 {
-  return headerBuffer.at(2);
+  return getHeaderWord<uint8_t>(2);
 }
 
 const uint8_t SmurfPacket::getTimingConfiguration() const
 {
-  return headerBuffer.at(3);
+  return getHeaderWord<uint8_t>(3);
 }
 
 const uint32_t SmurfPacket::getNumberChannels() const
 {
-  return *(reinterpret_cast<const uint32_t*>(&headerBuffer.at(4)));
+  return getHeaderWord<uint32_t>(4);
+}
+
+template <typename T>
+const T SmurfPacket::getHeaderWord(std::size_t offset) const
+{
+  return *(reinterpret_cast<const T*>(&headerBuffer.at(offset)));
 }
 
 void SmurfPacket::copyHeader(uint8_t* h)

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -235,7 +235,8 @@ SmurfPacket::SmurfPacket()
   packetLength(smurfheaderlength + smurfsamples * sizeof(avgdata_t)),
   headerBuffer(smurfheaderlength),
   payloadBuffer(smurfsamples),
-  header(headerBuffer.data())
+  header(headerBuffer.data()),
+  tba(&headerBuffer.at(headerTESDACOffset))
 {
   std::cout << "SmurfPacket object created:" << std::endl;
   std::cout << "Header length       = " << headerLength  << " bytes" << std::endl;
@@ -300,6 +301,11 @@ const uint8_t SmurfPacket::getTimingConfiguration() const
 const uint32_t SmurfPacket::getNumberChannels() const
 {
   return getHeaderWord<uint32_t>(headerNumberChannelOffset);
+}
+
+const int32_t SmurfPacket::getTESDAC(std::size_t index) const
+{
+  return tba.getWord(index);
 }
 
 const uint64_t SmurfPacket::getUnixTime() const

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -224,11 +224,11 @@ uint SmurfHeader::average_control(int num_averages) // returns num averages when
 ////////////////////////////////////////
 
 ////////////////////////////////////////
-////// + SmurfPacket definitions ///////
+////// + SmurfPacket_RO definitions ///////
 ////////////////////////////////////////
 
 // Default constructor
-SmurfPacket::SmurfPacket()
+SmurfPacket_RO::SmurfPacket_RO()
 :
   headerLength(smurfheaderlength),
   payloadLength(smurfsamples),
@@ -238,236 +238,236 @@ SmurfPacket::SmurfPacket()
   header(headerBuffer.data()),
   tba(&headerBuffer.at(headerTESDACOffset))
 {
-  std::cout << "SmurfPacket object created:" << std::endl;
+  std::cout << "SmurfPacket_RO object created:" << std::endl;
   std::cout << "Header length       = " << headerLength  << " bytes" << std::endl;
   std::cout << "Payload length      = " << payloadLength << " words" << std::endl;
   std::cout << "Total packet length = " << packetLength  << " bytes" << std::endl;
 }
 
-SmurfPacket::SmurfPacket(uint8_t* h)
+SmurfPacket_RO::SmurfPacket_RO(uint8_t* h)
 :
-  SmurfPacket()
+  SmurfPacket_RO()
 {
   copyHeader(h);
 }
 
-SmurfPacket::SmurfPacket(uint8_t* h, avgdata_t* d)
+SmurfPacket_RO::SmurfPacket_RO(uint8_t* h, avgdata_t* d)
 :
-  SmurfPacket(h)
+  SmurfPacket_RO(h)
 {
   copyData(d);
 }
 
-SmurfPacket::~SmurfPacket()
+SmurfPacket_RO::~SmurfPacket_RO()
 {
-  std::cout << "SmurfPacket object destroyed" << std::endl;
+  std::cout << "SmurfPacket_RO object destroyed" << std::endl;
 }
 
-const std::size_t SmurfPacket::getHeaderLength()  const
+const std::size_t SmurfPacket_RO::getHeaderLength()  const
 {
   return headerLength;
 }
 
-const std::size_t SmurfPacket::getPayloadLength() const
+const std::size_t SmurfPacket_RO::getPayloadLength() const
 {
   return payloadLength;
 }
 
-const std::size_t SmurfPacket::getPacketLength()  const
+const std::size_t SmurfPacket_RO::getPacketLength()  const
 {
   return packetLength;
 }
 
-const uint8_t SmurfPacket::getVersion() const
+const uint8_t SmurfPacket_RO::getVersion() const
 {
   return getHeaderWord<uint8_t>(headerVersionOffset);
 }
 
-const uint8_t SmurfPacket::getCrateID() const
+const uint8_t SmurfPacket_RO::getCrateID() const
 {
   return getHeaderWord<uint8_t>(headerCrateIDOffset);
 }
 
-const uint8_t SmurfPacket::getSlotNumber() const
+const uint8_t SmurfPacket_RO::getSlotNumber() const
 {
   return getHeaderWord<uint8_t>(headerSlotNumberOffset);
 }
 
-const uint8_t SmurfPacket::getTimingConfiguration() const
+const uint8_t SmurfPacket_RO::getTimingConfiguration() const
 {
   return getHeaderWord<uint8_t>(headerTimingConfigurationOffset);
 }
 
-const uint32_t SmurfPacket::getNumberChannels() const
+const uint32_t SmurfPacket_RO::getNumberChannels() const
 {
   return getHeaderWord<uint32_t>(headerNumberChannelOffset);
 }
 
-const int32_t SmurfPacket::getTESBias(std::size_t index) const
+const int32_t SmurfPacket_RO::getTESBias(std::size_t index) const
 {
   return tba.getWord(index);
 }
 
-const uint64_t SmurfPacket::getUnixTime() const
+const uint64_t SmurfPacket_RO::getUnixTime() const
 {
   return getHeaderWord<uint64_t>(headerUnixTimeOffset);
 }
 
-const uint32_t SmurfPacket::getFluxRampIncrement() const
+const uint32_t SmurfPacket_RO::getFluxRampIncrement() const
 {
   return getHeaderWord<uint32_t>(headerFluxRampIncrementOffset);
 }
 
-const uint32_t SmurfPacket::getFluxRampOffset() const
+const uint32_t SmurfPacket_RO::getFluxRampOffset() const
 {
   return getHeaderWord<uint32_t>(headerFluxRampOffsetOffset);
 }
 
-const uint32_t SmurfPacket::getCounter0() const
+const uint32_t SmurfPacket_RO::getCounter0() const
 {
   return getHeaderWord<uint32_t>(headerCounter0Offset);
 }
 
-const uint32_t SmurfPacket::getCounter1() const
+const uint32_t SmurfPacket_RO::getCounter1() const
 {
   return getHeaderWord<uint32_t>(headerCounter1Offset);
 }
 
-const uint64_t SmurfPacket::getCounter2() const
+const uint64_t SmurfPacket_RO::getCounter2() const
 {
   return getHeaderWord<uint64_t>(headerCounter2Offset);
 }
 
-const uint32_t SmurfPacket::getAveragingResetBits() const
+const uint32_t SmurfPacket_RO::getAveragingResetBits() const
 {
   return getHeaderWord<uint32_t>(headerAveragingResetBitsOffset);
 }
 
-const uint32_t SmurfPacket::getFrameCounter() const
+const uint32_t SmurfPacket_RO::getFrameCounter() const
 {
   return getHeaderWord<uint32_t>(headerFrameCounterOffset);
 }
 
-const uint32_t SmurfPacket::getTESRelaySetting() const
+const uint32_t SmurfPacket_RO::getTESRelaySetting() const
 {
   return getHeaderWord<uint32_t>(headerTESRelaySettingOffset);
 }
 
-const uint64_t SmurfPacket::getExternalTimeClock() const
+const uint64_t SmurfPacket_RO::getExternalTimeClock() const
 {
   return getHeaderWord<uint64_t>(headerExternalTimeClockOffset);
 }
 
-const uint8_t SmurfPacket::getControlField() const
+const uint8_t SmurfPacket_RO::getControlField() const
 {
   return getHeaderWord<uint8_t>(headerControlFieldOffset);
 }
 
-const bool SmurfPacket::getClearAverageBit() const
+const bool SmurfPacket_RO::getClearAverageBit() const
 {
   return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x01);
 }
-const bool SmurfPacket::getDisableStreamBit() const
+const bool SmurfPacket_RO::getDisableStreamBit() const
 {
   return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x02);
 }
-const bool SmurfPacket::getDisableFileWriteBit() const
+const bool SmurfPacket_RO::getDisableFileWriteBit() const
 {
   return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x04);
 }
-const bool SmurfPacket::getReadConfigEachCycleBit() const
+const bool SmurfPacket_RO::getReadConfigEachCycleBit() const
 {
   return (getHeaderWord<uint8_t>(headerControlFieldOffset) & 0x08);
 }
-const uint8_t SmurfPacket::getTestMode() const
+const uint8_t SmurfPacket_RO::getTestMode() const
 {
   return ((getHeaderWord<uint8_t>(headerControlFieldOffset) >> 4) & 0x0f);
 }
 
-const uint8_t SmurfPacket::getTestParameters() const
+const uint8_t SmurfPacket_RO::getTestParameters() const
 {
   return getHeaderWord<uint8_t>(headerTestParametersOffset);
 }
 
-const uint16_t SmurfPacket::getNumberRows() const
+const uint16_t SmurfPacket_RO::getNumberRows() const
 {
   return getHeaderWord<uint16_t>(headerNumberRowsOffset);
 }
 
-const uint16_t SmurfPacket::getNumberRowsReported() const
+const uint16_t SmurfPacket_RO::getNumberRowsReported() const
 {
   return getHeaderWord<uint16_t>(headerNumberRowsReportedOffset);
 }
 
-const uint16_t SmurfPacket::getRowLength() const
+const uint16_t SmurfPacket_RO::getRowLength() const
 {
   return getHeaderWord<uint16_t>(headerRowLengthOffset);
 }
 
-const uint16_t SmurfPacket::getDataRate() const
+const uint16_t SmurfPacket_RO::getDataRate() const
 {
   return getHeaderWord<uint16_t>(headerDataRateOffset);
 }
 
 template <typename T>
-const T SmurfPacket::getHeaderWord(std::size_t offset) const
+const T SmurfPacket_RO::getHeaderWord(std::size_t offset) const
 {
   return *(reinterpret_cast<const T*>(&headerBuffer.at(offset)));
 }
 
-void SmurfPacket::copyHeader(uint8_t* h)
+void SmurfPacket_RO::copyHeader(uint8_t* h)
 {
   memcpy(headerBuffer.data(), h, headerLength);
 }
 
-void SmurfPacket::copyData(avgdata_t* d)
+void SmurfPacket_RO::copyData(avgdata_t* d)
 {
   memcpy(payloadBuffer.data(), d, payloadLength * sizeof(avgdata_t));
 }
 
-void SmurfPacket::writeToFile(uint fd) const
+void SmurfPacket_RO::writeToFile(uint fd) const
 {
   write(fd, headerBuffer.data(), headerLength);
   write(fd, payloadBuffer.data(), payloadLength * sizeof(avgdata_t));
 }
 
-SmurfHeader* SmurfPacket::getHeaderPtr()
+SmurfHeader* SmurfPacket_RO::getHeaderPtr()
 {
   return &header;
 }
 
-const avgdata_t SmurfPacket::getValue(std::size_t index) const
+const avgdata_t SmurfPacket_RO::getValue(std::size_t index) const
 {
   return payloadBuffer.at(index);
 }
 
-void SmurfPacket::setValue(std::size_t index, avgdata_t value)
+void SmurfPacket_RO::setValue(std::size_t index, avgdata_t value)
 {
   payloadBuffer.at(index) = value;
 }
 
-const uint8_t SmurfPacket::getHeaderByte(std::size_t index) const
+const uint8_t SmurfPacket_RO::getHeaderByte(std::size_t index) const
 {
   return headerBuffer.at(index);
 }
 
-void SmurfPacket::setHeaderByte(std::size_t index, uint8_t value)
+void SmurfPacket_RO::setHeaderByte(std::size_t index, uint8_t value)
 {
   headerBuffer.at(index) = value;
 }
 
-void SmurfPacket::getHeaderArray(uint8_t* h) const
+void SmurfPacket_RO::getHeaderArray(uint8_t* h) const
 {
   memcpy(h, headerBuffer.data(), headerLength);
 }
 
-void SmurfPacket::getDataArray(avgdata_t* d) const
+void SmurfPacket_RO::getDataArray(avgdata_t* d) const
 {
   memcpy(d, payloadBuffer.data(), payloadLength * sizeof(avgdata_t));
 }
 
 ////////////////////////////////////////
-////// - SmurfPacket definitions ///////
+////// - SmurfPacket_RO definitions ///////
 ////////////////////////////////////////
 
 uint64_t pull_bit_field(uint8_t *ptr, uint offset, uint width)

--- a/src/smurf_packet.cpp
+++ b/src/smurf_packet.cpp
@@ -298,7 +298,7 @@ SmurfHeader* SmurfPacket::getHeaderPtr()
   return &header;
 }
 
-const avgdata_t SmurfPacket::getData(std::size_t index) const
+const avgdata_t SmurfPacket::getValue(std::size_t index) const
 {
   return payloadBuffer.at(index);
 }

--- a/src/smurf_processor.cpp
+++ b/src/smurf_processor.cpp
@@ -97,6 +97,12 @@ pktWriterThread      ( std::thread( &SmurfProcessor::pktWriter, this )     )
   thread_ = new boost::thread(&SmurfProcessor::runThread, this);
 
   initialized = true;
+
+  // Set thread names
+  if( pthread_setname_np( pktTransmitterThread.native_handle(), "pktTransmitter" ) )
+    perror( "pthread_setname_np failed for pktTransmitterThread" );
+  if( pthread_setname_np( pktWriterThread.native_handle(), "pktWriter" ) )
+    perror( "pthread_setname_np failed for pktWriterThread" );
 }
 
 // This function does most of the work. Runs every smurf frame

--- a/src/smurf_processor.cpp
+++ b/src/smurf_processor.cpp
@@ -360,7 +360,7 @@ void SmurfProcessor::frameToBuffer( ris::FramePtr frame, uint8_t * const buffer)
   }
 }
 
-void SmurfProcessor:: transmitter()
+void SmurfProcessor::transmitter()
 {
   std::cout << "Transmitter thread started..." << std::endl;
 

--- a/src/smurf_processor.cpp
+++ b/src/smurf_processor.cpp
@@ -20,7 +20,7 @@
 
 SmurfProcessor::SmurfProcessor()
 : ris::Slave(),
-txBuffer          ( 10, smurfheaderlength + smurfsamples * sizeof(avgdata_t) ),
+txBuffer          ( 10                                                       ),
 runTxThread       ( true                                                     ),
 transmitterThread ( std::thread( &SmurfProcessor::transmitter, this )        ),
 txPacketLossCnt   ( 0                                                        )
@@ -274,10 +274,10 @@ void SmurfProcessor::runThread()
           if ( ! txBuffer.isFull() )
           {
             // Add the packet into the buffer
-            smurf_tx_data_t* smurfPackage = txBuffer.getWritePtr();
+            SmurfPacket sp = txBuffer.getWritePtr();
 
-            memcpy(smurfPackage, H->header, smurfheaderlength);
-            memcpy(smurfPackage+smurfheaderlength, average_samples, smurfsamples * sizeof(avgdata_t));
+            sp->copyHeader(H->header);
+            sp->copyData(average_samples);
 
             // Mark the writing operation as done.
             txBuffer.doneWriting();

--- a/src/smurf_processor.cpp
+++ b/src/smurf_processor.cpp
@@ -23,7 +23,6 @@ SmurfProcessor::SmurfProcessor()
 txBuffer           ( 10, 2                                             ),
 runTxThread        ( true                                              ),
 transmitterThread  ( std::thread( &SmurfProcessor::transmitter, this ) ),
-txPacketLossCnt    ( 0                                                 ),
 pktReaderIndexTx   ( 0                                                 ),
 pktReaderIndexFile ( 1                                                 )
 {
@@ -401,12 +400,7 @@ void SmurfProcessor:: transmitter()
 
 void SmurfProcessor::printTransmitStatistic() const
 {
-  std::cout << "=============================="             << std::endl;
-  std::cout << "SMuRF Transmission statistics:"             << std::endl;
-  std::cout << "=============================="             << std::endl;
-  std::cout << "Package loss counter : " << txPacketLossCnt << std::endl;
   txBuffer.printStatistic();
-  std::cout << "=============================="             << std::endl;
 }
 
 SmurfProcessor::~SmurfProcessor() // destructor

--- a/src/smurf_processor.cpp
+++ b/src/smurf_processor.cpp
@@ -20,10 +20,12 @@
 
 SmurfProcessor::SmurfProcessor()
 : ris::Slave(),
-txBuffer          ( 10                                                       ),
-runTxThread       ( true                                                     ),
-transmitterThread ( std::thread( &SmurfProcessor::transmitter, this )        ),
-txPacketLossCnt   ( 0                                                        )
+txBuffer           ( 10, 2                                             ),
+runTxThread        ( true                                              ),
+transmitterThread  ( std::thread( &SmurfProcessor::transmitter, this ) ),
+txPacketLossCnt    ( 0                                                 ),
+pktReaderIndexTx   ( 0                                                 ),
+pktReaderIndexFile ( 1                                                 )
 {
   rxCount = 0;
   rxBytes = 0;
@@ -270,31 +272,24 @@ void SmurfProcessor::runThread()
         // Add a SMuRF packet in the TX buffer so it can be processed by the transmit method
         try
         {
-          // Check if there is room in the buffer
-          if ( ! txBuffer.isFull() )
-          {
-            // Add the packet into the buffer
-            SmurfPacket sp = txBuffer.getWritePtr();
+          // Add the packet into the buffer
+          SmurfPacket sp = txBuffer.getWritePtr();  // Get write pointer to buffer area
+          sp->copyHeader(H->header);                // Write the header content
+          sp->copyData(average_samples);            // Write the data content
 
-            sp->copyHeader(H->header);
-            sp->copyData(average_samples);
-
-            // Mark the writing operation as done.
-            txBuffer.doneWriting();
-          }
-          else
-          {
-            // Increase the loss counter is we couldn't add a new packet into the buffer
-            ++txPacketLossCnt;
-          }
+          // Mark the writing operation as done.
+          txBuffer.doneWriting();
         }
         catch (std::runtime_error &e)
         {
           std::cout << "SmurfReceiver: Exception caught when writing the data buffer: " << e.what() << std::endl;
         }
 
-        D->write_file(H->header, smurfheaderlength, average_samples, smurfsamples, C->data_frames,
-                      C->data_file_name, C->file_name_extend, H->disable_file_write());
+        // Write the packet to file
+        D->write_file(txBuffer.getReadPtr(pktReaderIndexFile), C);
+
+        // Tell the buffer we are done reading this area
+        txBuffer.doneReading(pktReaderIndexFile);
       }
 
       // tcpbuf   = NULL;  // returns location to put data (8 bytes beyond tcp start)
@@ -366,7 +361,7 @@ void SmurfProcessor::frameToBuffer( ris::FramePtr frame, uint8_t * const buffer)
   }
 }
 
-void SmurfProcessor::transmitter()
+void SmurfProcessor:: transmitter()
 {
   std::cout << "Transmitter thread started..." << std::endl;
 
@@ -374,7 +369,7 @@ void SmurfProcessor::transmitter()
   for(;;)
   {
     // Check the status of the data buffer
-    if ( txBuffer.isEmpty() )
+    if ( txBuffer.isEmpty(pktReaderIndexTx) )
     {
       // If the buffer is empty, wait until new data is ready, with a 10s timeout
       std::unique_lock<std::mutex> lock(*txBuffer.getMutex());
@@ -382,12 +377,12 @@ void SmurfProcessor::transmitter()
     }
     else
     {
-      // Process new data available in the buffer
-      // std::cout << "   +++ transmitter waking up, new data is ready... +++" << std::endl;
       try
       {
-        transmit(txBuffer.getReadPtr());
-        txBuffer.doneReading();
+        // Call processing method passing a read pointer to the buffer area
+        transmit(txBuffer.getReadPtr(pktReaderIndexTx));
+        // Tell the buffer we are done reading this packet
+        txBuffer.doneReading(pktReaderIndexTx);
       }
       catch (std::runtime_error &e)
       {
@@ -629,11 +624,11 @@ SmurfDataFile::SmurfDataFile(void) : open_(false), part_(0)
   fd = 0; // shows that we don't have a pointer yet
 }
 
-uint SmurfDataFile::write_file(uint8_t *header, uint header_bytes, avgdata_t *data, uint data_words, uint frames_to_write, char *fname, int name_mode,  bool disable)
+uint SmurfDataFile::write_file(SmurfPacket_RO packet, SmurfConfig *config)
 {
   time_t tx;
   char tmp[100]; // for strings
-  if(disable)
+  if(packet->getDisableFileWriteBit())
   {
     part_ = 0;
 
@@ -648,9 +643,9 @@ uint SmurfDataFile::write_file(uint8_t *header, uint header_bytes, avgdata_t *da
     return(frame_counter);
   }
 
-  if ( (name_mode==0) && (0 != strcmp(fname, filename))) // name has changed.
+  if ( (config->file_name_extend==0) && (0 != strcmp(config->data_file_name, filename))) // name has changed.
   {
-    printf("file name has changed from %s to %s \n", filename, fname);
+    printf("file name has changed from %s to %s \n", filename, config->data_file_name);
     if(fd)
       close(fd); // close existing file if its open
 
@@ -660,9 +655,9 @@ uint SmurfDataFile::write_file(uint8_t *header, uint header_bytes, avgdata_t *da
   if(!fd) // need to open a file
   {
     memset(filename, 0, 1024); // zero for now
-    strcat(filename, fname); // add file name
+    strcat(filename, config->data_file_name); // add file name
 
-    if (name_mode)
+    if (config->file_name_extend)
     {
       tx = time(NULL);
       sprintf(tmp, ".part_%05u", part_);  // LAZY - need to use a real time converter.
@@ -683,13 +678,12 @@ uint SmurfDataFile::write_file(uint8_t *header, uint header_bytes, avgdata_t *da
       printf("opened file %s  fd = %d \n", filename, fd);
   }
 
-  memcpy(frame, header, header_bytes);
-  // memcpy(frame + h_num_channels_offset, &data_words, 4); // UGLY horrible kludge, need to fix.
-  memcpy(frame+header_bytes, data, data_words * sizeof(avgdata_t));
-  write(fd, frame, header_bytes + data_words * sizeof(avgdata_t));
+  // Write packet to file
+  packet->writeToFile(fd);
+
   frame_counter++;
 
-  if(frame_counter >= frames_to_write)
+  if(frame_counter >= config->data_frames)
   {
     if(fd)
       close(fd);

--- a/src/tes_bias_array.cpp
+++ b/src/tes_bias_array.cpp
@@ -17,7 +17,7 @@ void TesBiasArray::setPtr(uint8_t *p)
   pData = p;
 }
 
-void TesBiasArray::setWord(const WordIndex& index, int value) const
+void TesBiasArray::setWord(const WordIndex& index, int32_t value) const
 {
   if (index >= TesBiasCount)
     throw std::runtime_error("Trying to write a TES bias value in an address of out the buffer range.");
@@ -52,7 +52,7 @@ void TesBiasArray::setWord(const WordIndex& index, int value) const
   }
 };
 
-int TesBiasArray::getWord(const WordIndex& index) const
+const int32_t TesBiasArray::getWord(const WordIndex& index) const
 {
   if (index >= TesBiasCount)
     throw std::runtime_error("Trying to read a TES bias value in an address of out the buffer range.");

--- a/src/tes_bias_array.cpp
+++ b/src/tes_bias_array.cpp
@@ -1,0 +1,74 @@
+#include "tes_bias_array.h"
+
+TesBiasArray::TesBiasArray(uint8_t *p)
+:
+  pData(p)
+{
+
+}
+
+TesBiasArray::~TesBiasArray()
+{
+
+}
+
+void TesBiasArray::setPtr(uint8_t *p)
+{
+  pData = p;
+}
+
+void TesBiasArray::setWord(const WordIndex& index, int value) const
+{
+  if (index >= TesBiasCount)
+    throw std::runtime_error("Trying to write a TES bias value in an address of out the buffer range.");
+
+  if (index.Word() == 0)
+  {
+    // Create an union pointing to the block
+    uint8_t *b = (pData + 5*index.Block());
+
+    // Create an union with the passed value
+    U v { value };
+    *b++ = v.byte[0];
+    *b++ = v.byte[1];
+    uint8_t temp = *b;
+    temp &= 0xf0;
+    temp |= (v.byte[2] & 0x0f);
+    *b = temp;
+  }
+  else
+  {
+    // Create an union pointing to the block
+    uint8_t *b = (pData + 5*index.Block() + 2);
+
+    // Create an union with the passed value
+    U v { value << 4 };
+    uint8_t temp = *b;
+    temp &= 0x0f;
+    temp |= (v.byte[0] & 0xf0);
+    *b++ = temp;
+    *b++ = v.byte[1];
+    *b = v.byte[2];
+  }
+};
+
+int TesBiasArray::getWord(const WordIndex& index) const
+{
+  if (index >= TesBiasCount)
+    throw std::runtime_error("Trying to read a TES bias value in an address of out the buffer range.");
+
+  std::size_t offset(0), shift(0);
+
+  if (index.Word())
+  {
+    offset = 2;
+    shift = 4;
+  }
+
+  return S { static_cast<int>( *( reinterpret_cast<uint32_t*>( pData + 5*index.Block() + offset ) ) >> shift )  }.word;
+}
+
+std::mutex* TesBiasArray::getMutex()
+{
+  return &mut;
+};


### PR DESCRIPTION
- Add new class `SmurfPacket` to handle SMuRF packet,
- The method `transmit` now receive a (smart) pointer to a SmurfPacket object,
- Write a SMuRF packet to a file is now a method of the SmurfPacket class,
- Use  a thread to write the SMuRF packet to files
- Use a circular buffer to store new SMuRF packets (SmurfPacket objects). 
    - Multiple readers can read the packet from the buffer using; there are 2 readers in this case: the user defined transmitter, and the file writer
    - The buffer provides (smart) pointers to the writer and readers, without copying the data around 